### PR TITLE
Added detection of wether it is running guix's emacs

### DIFF
--- a/early-init.el
+++ b/early-init.el
@@ -68,7 +68,7 @@
               (equal system-type 'windows-nt))
     ;; Since there is no windows implementation of guix
     (string-prefix-p "/gnu/store/"
-                     (file-chase-links
+                     (file-truename
                       (executable-find
                        (car command-line-args))))))
 


### PR DESCRIPTION
A new function (`rational-runs-guix-emacs-p') to detect if we are running an emacs in the /gnu/store/.
Also sets the default value of `rational-prefer-guix-packages' to the result of the new added function.

Of course, this could be overriden on `early-config.el', if needed.