### PR TITLE
Remove corfu-doc as it was merged into corfu

### DIFF
--- a/modules/rational-completion.el
+++ b/modules/rational-completion.el
@@ -97,7 +97,7 @@ folder, otherwise delete a word"
 (customize-set-variable 'corfu-auto-delay 0.0) ; No delay for completion
 (customize-set-variable 'corfu-echo-documentation 0.25) ; Echo docs for current completion option
 
-(global-corfu-mode 1)
+(corfu-global-mode 1)
 
 (add-hook 'corfu-mode-hook #'corfu-doc-mode)
 (define-key corfu-map (kbd "M-p") #'corfu-doc-scroll-down)

--- a/modules/rational-completion.el
+++ b/modules/rational-completion.el
@@ -16,7 +16,6 @@
 
 (rational-package-install-package 'cape)
 (rational-package-install-package 'consult)
-(rational-package-install-package 'corfu-doc)
 (rational-package-install-package 'corfu)
 (rational-package-install-package 'embark)
 (rational-package-install-package 'embark-consult)

--- a/modules/rational-completion.el
+++ b/modules/rational-completion.el
@@ -89,7 +89,7 @@ folder, otherwise delete a word"
 
 
 ;;; Corfu
-
+(require 'corfu)
 ;; Setup corfu for popup like completion
 (customize-set-variable 'corfu-cycle t) ; Allows cycling through candidates
 (customize-set-variable 'corfu-auto t)  ; Enable auto completion


### PR DESCRIPTION
Earlier today I was having issues pulling `corfu-doc` from MELPA earlier which prompted me to discover that the author of corfo-doc is fairly close to merging into into corfu's master branch.

See https://github.com/minad/corfu/pull/178

As you can see in the PR - the only API change has been with `(global-corfu-mode)` becoming `(corfu-global-mode)`