### PR TITLE
initial config for latex and pdf files

### DIFF
--- a/modules/crafted-latex.el
+++ b/modules/crafted-latex.el
@@ -1,0 +1,137 @@
+;;; crafted-latex.el -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2022
+;; SPDX-License-Identifier: MIT
+
+;; Author: System Crafters Community
+
+;; Commentary
+
+;; Sane defaults for LaTeX editing
+
+;;; Code:
+
+(defgroup crafted-latex '()
+  "LaTeX configuration for Crafted Emacs."
+  :tag "Crafted LaTeX"
+  :group 'crafted)
+
+(defvar crafted-latex-latexp
+  "is the latex executable found"
+  :group 'crafted-latex
+  :type 'string
+  :set (executable-find "latex"))
+
+(defvar crafted-latex-latexmkp
+  "is the latexmk executable found"
+  :group 'crafted-latex
+  :type 'string
+  :set (executable-find "latexmk"))
+
+(defcustom crafted-latex-use-pdf-tools
+  "use pdf-tools as the pdf reader
+   (this is automatic if you load `crafted-pdf-reader')"
+  :group 'crafted-latex
+  :type 'boolean
+  :set nil)
+
+(defcustom crafted-latex-inhibit-latexmk
+  "When set to `nil', the package auctex-latexmk gets installed if the
+latex and latexmk executable are found
+
+This package contains a bug which might make it crash during loading
+(with a bug related to tex-buf) on newer systems. For this reason, we inhibit
+the installation of this package by default.
+
+
+If you encounter the bug, you keep this package inhibited. You can install
+a fix (not on melpa) with the following recipe, and the configuration in this file
+will still work
+'(auctex-latexmk :fetcher git :host github :repo \"wang1zhen/auctex-latexmk\")"
+  :group 'crafted-latex
+  :type 'boolean
+  :set t)
+
+
+;; only install and load auctex when the latex executable is found,
+;; otherwise it crashes when loading
+
+(when crafted-latex-latexp
+  (crafted-package-install-package 'auctex)
+
+  (with-eval-after-load 'latex
+    (customize-set-variable 'TeX-auto-save t)
+    (customize-set-variable 'TeX-parse-self t)
+    (setq-default TeX-master nil)
+
+    ;; compile to pdf
+    (tex-pdf-mode)
+
+    ;; correlate the source and the output
+    (TeX-source-correlate-mode)
+
+    ;; set a correct indentation in a few additional environments
+    (add-to-list 'LaTeX-indent-environment-list '("lstlisting" current-indentation))
+    (add-to-list 'LaTeX-indent-environment-list '("tikzcd" LaTeX-indent-tabular))
+    (add-to-list 'LaTeX-indent-environment-list '("tikzpicture" current-indentation))
+
+    ;; add a few macros and environment as verbatim
+    (add-to-list 'LaTeX-verbatim-environments "lstlisting")
+    (add-to-list 'LaTeX-verbatim-environments "Verbatim")
+    (add-to-list 'LaTeX-verbatim-macros-with-braces "lstinline")
+    (add-to-list 'LaTeX-verbatim-macros-with-delims "lstinline")
+
+    ;; to use pdfview with auctex
+    (when crafted-latex-use-pdf-tools
+      (customize-set-variable 'TeX-view-program-selection '((output-pdf "PDF Tools")))
+      (customize-set-variable 'TeX-view-program-list '(("PDF Tools" TeX-pdf-tools-sync-view)))
+      (customize-set-variable 'TeX-source-correlate-start-server t))
+
+    ;; electric pairs in auctex
+    (customize-set-variable 'TeX-electric-sub-and-superscript t)
+    (customize-set-variable 'LaTeX-electric-left-right-brace t)
+    (customize-set-variable 'TeX-electric-math (cons "$" "$"))
+
+    ;; open all buffers with the math mode and auto-fill mode
+    (add-hook 'LaTeX-mode-hook #'auto-fill-mode)
+    (add-hook 'LaTeX-mode-hook #'LaTeX-math-mode)
+
+    ;; add support for references
+    (add-hook 'LaTeX-mode-hook 'turn-on-reftex)
+    (customize-set-variable 'reftex-plug-into-AUCTeX t)
+
+    ;; to have the buffer refresh after compilation
+    (add-hook 'TeX-after-compilation-finished-functions #'TeX-revert-document-buffer)
+    ))
+
+;; message the user if the latex executable is not found
+(add-hook 'tex-mode-hook
+          (lambda () (unless crafted-latex-latexp (message "latex executable not found"))))
+
+
+;; The following is to use auctex with latexmk.
+(defun crafted-latex--install-latexmk ()
+  "install the auctex-latexmk package when the latex and latexmk executable
+are found (see `crafted-latex-inhibit-latexmk' )"
+  (when (and crafted-latex-latexp
+             crafted-latex-latexmkp)
+  (crafted-package-install-package 'auctex-latexmk)))
+
+(defun crafted-latex--watch-inhibit-latexmk (sym val op buf)
+  "watcher for the `crafted-latex-inhibit-latexmk' variable"
+  (unless val
+    (crafted-latex--install-latexmk)))
+
+(add-variable-watcher 'crafted-latex-inhibit-latexmk
+                      #'crafted-latex--watch-inhibit-latexmk)
+
+(when (and crafted-latex-latexp
+           crafted-latex-latexmkp)
+  (with-eval-after-load 'latex
+    (when (require 'auctex-latexmk nil 'noerror)
+      (with-eval-after-load 'auctex-latexmk
+        (auctex-latexmk-setup)
+        (customize-set-variable 'auctex-latexmk-inherit-TeX-PDF-mode t))
+          (add-hook 'TeX-mode-hook '(lambda () (setq TeX-command-default "LatexMk"))))))
+
+(provide 'crafted-latex)

--- a/modules/crafted-pdf-reader.el
+++ b/modules/crafted-pdf-reader.el
@@ -1,0 +1,25 @@
+;;; crafted-pdf-reader.el -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2022
+;; SPDX-License-Identifier: MIT
+
+;; Author: System Crafters Community
+
+;; Commentary
+
+;; Configuration for the pdf-tools package to read pdf files
+
+;;; Code:
+
+(crafted-package-install-package '(pdf-tools))
+
+(add-hook 'doc-view-mode-hook (lambda () (require 'pdf-tools)))
+
+(with-eval-after-load 'pdf-tools
+  (pdf-tools-install)
+  (setq-default pdf-view-display-size 'fit-width))
+
+(when (boundp 'crafted-latex-use-pdf-tools)
+  (customize-set-variable 'crafted-latex-use-pdf-tools t))
+
+(provide 'crafted-pdf-reader)


### PR DESCRIPTION
Hi, thanks a lot for your work maintaining this awesome project.
Here is a basic configuration for LaTeX that I use and which works pretty well.

I set it all up using AUCTeX, which albeit not a part of emacs is still a GNU project. I tried to follow the idea of crafted emacs, to stick as much as possible with a minimalistic and non opinionated configuration. I still had some decisions to make along the way, in order to provide a good out-of-the-box experience.

- Because of the quirks of LaTeX, it sometimes need to be compiled several times in a row in order to get everything right. There is a very nice helper script called latexmk, but it is not compatible with AUCTeX out of the box, so I chose to add the package `auctex-latexmk`. Others might not agree with this choice, especially because this package may have a dependency problem on MELPA (it has on one of my system and not in the other), and I made a little workaround that. I do not mind removing this package if people think it's better. 
- I assumed that LaTeX was used to procude pdf files and not postscript. I believe that is what most people use it for anyway, so it is not very opinionated.
- I provided the option to read the pdf inside of emacs, but I added a support for the `pdf-view` mode, except of the native `DocVIew` mode. Again I do not think this is very opinionated, since this package provides much more features such as correlating the source and the output.

On the other hands, here are a few packages and functions that I did not include, as I do not think they are suited to everyone's use of LaTeX, or require a choice that I should not make in place of the user:
- I did not assume that the user has a LSP for latex. There are 2 of them and I do not think I should make the choice instead of the user. If you want me to, I could check if `eglot` is loaded and if one of the language server is installed, and if so add `eglot-ensure` as a hook to `LaTeX-mode`
- I did not use `xenops`, even though I personally love it, because it provides something that I know a lot of people don't care about or don't like
- I did not add any additional package to manage citations. I do not know them well enough. I have had a look at `citar`, mentioned in https://github.com/SystemCrafters/crafted-emacs/issues/130, and I really like it. The fact that it integrates well with `vertico`, `embark`, `marginalia`... makes me think that it could be integrated to `crafted-emacs`, but it is not specific to `LaTeX`. Other kinds of packages exist for citations, and could be added by people who know them better than me.
- I did not set up a spell-checker in LaTeX mode, as I think some people would not like that