### PR TITLE
Delete references to removed `modules/crafted-use-package.el`

### DIFF
--- a/README.org
+++ b/README.org
@@ -133,7 +133,6 @@ clone from listing [[li#git_clone]]. Follow the links to each to get more
 information about how they can be configured!
 
 - [[file:modules/crafted-defaults.el][crafted-defaults]] :: Sensible default settings for Emacs
-- [[file:modules/crafted-use-package.el][crafted-use-package]] :: Configuration for =use-package=
 - [[file:modules/crafted-updates.el][crafted-updates]] :: Tools to upgrade Crafted Emacs
 - [[file:modules/crafted-completion.el][crafted-completion]] :: A better selection framework configuration based on
   =Vertico=
@@ -227,7 +226,6 @@ config might begin like this:
 #+caption: Example of basic Crafted Emacs =config.el= file.
 #+begin_src emacs-lisp
   (require 'crafted-defaults)    ; Sensible default settings for Emacs
-  (require 'crafted-use-package) ; Configuration for `use-package`
   (require 'crafted-updates)     ; Tools to upgrade Crafted Emacs
   (require 'crafted-completion)  ; selection framework based on `vertico`
   (require 'crafted-ui)          ; Better UI experience (modeline etc.)

--- a/examples/example-config.el
+++ b/examples/example-config.el
@@ -19,7 +19,6 @@
 ;; So, if you prefer Vim-style keybindings over vanilla Emacs keybindings
 ;; remove the comment in the line about `crafted-evil' below.
 (require 'crafted-defaults)    ; Sensible default settings for Emacs
-(require 'crafted-use-package) ; Configuration for `use-package`
 (require 'crafted-updates)     ; Tools to upgrade Crafted Emacs
 (require 'crafted-completion)  ; selection framework based on `vertico`
 (require 'crafted-ui)          ; Better UI experience (modeline etc.)

--- a/examples/example-config.org
+++ b/examples/example-config.org
@@ -47,7 +47,6 @@ Vim-style keybindings over vanilla Emacs keybindings remove the comment
 in the line about =crafted-evil= below.
 #+begin_src emacs-lisp
   (require 'crafted-defaults)    ; Sensible default settings for Emacs
-  (require 'crafted-use-package) ; Configuration for `use-package`
   (require 'crafted-updates)     ; Tools to upgrade Crafted Emacs
   (require 'crafted-completion)  ; selection framework based on `vertico`
   (require 'crafted-ui)          ; Better UI experience (modeline etc.)


### PR DESCRIPTION
`modules/crafted-use-package.el` was deleted in commit #b331d44 but was still referenced in the readme and examples.