### PR TITLE
Fix early-init typo "crafted-boostrap-directory"

### DIFF
--- a/bootstrap/crafted-package.el
+++ b/bootstrap/crafted-package.el
@@ -56,7 +56,7 @@ This is called when `early-init.el' runs."
                                                        crafted-package-system
                                                        ;; In case both above are nil
                                                        'package)))))
-         (module-path (expand-file-name (symbol-name module) crafted-boostrap-directory)))
+         (module-path (expand-file-name (symbol-name module) crafted-bootstrap-directory)))
     (if (file-exists-p module-path)
         (load module-path)
       (error "Could not find module %s" module))))

--- a/early-init.el
+++ b/early-init.el
@@ -102,10 +102,10 @@ customizations made by packages.")
 ;;; Package system
 ;; Load the package-system.  If needed, the user could customize the
 ;; system to use in `early-config.el'.
-(defvar crafted-boostrap-directory (expand-file-name "bootstrap/" user-emacs-directory)
+(defvar crafted-bootstrap-directory (expand-file-name "bootstrap/" user-emacs-directory)
   "Package system bootstrap configuration.")
 
-(load (expand-file-name "crafted-package.el" crafted-boostrap-directory))
+(load (expand-file-name "crafted-package.el" crafted-bootstrap-directory))
 ;; this is the default
 ;; (setq crafted-package-system 'package)
 (crafted-package-bootstrap crafted-package-system)


### PR DESCRIPTION
Found a few typos when looking through early-init.