### PR TITLE
Add error handling around crafted-updates, cleanup comments

### DIFF
--- a/modules/crafted-startup.el
+++ b/modules/crafted-startup.el
@@ -153,13 +153,13 @@ splash screen in another window."
         (make-local-variable 'crafted-startup-screen-inhibit-startup-screen)
         (if pure-space-overflow
             (insert pure-space-overflow-message))
-        ;; (unless concise
-        ;;   (fancy-splash-head))
         (dolist (text crafted-startup-text)
           (apply #'fancy-splash-insert text)
           (insert "\n"))
         (crafted-updates-check-for-latest)
-        (if (> (crafted-updates--get-new-commit-count) 0)
+        (if (> (condition-case nil
+                   (crafted-updates--get-new-commit-count)
+                 (error 0)) 0)
             (fancy-splash-insert
              :face '(variable-pitch font-lock-keyword-face bold)
              (format "%s : " (crafted-updates-status-message))
@@ -170,11 +170,10 @@ splash screen in another window."
              "\n")
           (fancy-splash-insert
            :face '(variable-pitch font-lock-keyword-face bold)
-           (format "%s\n" (crafted-updates-status-message))))
+           (format "%s\n" (condition-case nil
+                              (crafted-updates-status-message)
+                            (error "Crafted Emacs status could not be determined.")))))
         (insert "\n\n")
-        ;; (skip-chars-backward "\n")
-        ;; (delete-region (point) (point-max))
-        ;; (insert "\n")
         (crafted-startup-recentf)
         (skip-chars-backward "\n")
         (delete-region (point) (point-max))


### PR DESCRIPTION
Removed left-over commented code which was from Emacs startup.el file.

If the calls to crafted-updates-* fail, the error prevents the startup screen from showing. Added error handling to help prevent that situation.