### PR TITLE
fix typo in cljr-add-keybindings-with-prefix

### DIFF
--- a/docs/crafted-emacs.info
+++ b/docs/crafted-emacs.info
@@ -1334,7 +1334,7 @@ prefix is set to ‘C-c r’ to avoid conflicts with CIDER.  To change this
 to something else (for example ‘C-c C-m’ as mentioned on the github
 page) use the following snippet:
 
-          (clj-add-keybindings-with-prefix "C-c C-m")
+          (cljr-add-keybindings-with-prefix "C-c C-m")
 
 
 File: crafted-emacs.info,  Node: Scheme/Racket,  Prev: Clojure,  Up: Crafted Emacs Lisp Module

--- a/docs/crafted-lisp.org
+++ b/docs/crafted-lisp.org
@@ -107,7 +107,7 @@
    as mentioned on the github page) use the following snippet:
 
    #+begin_src emacs-lisp
-     (clj-add-keybindings-with-prefix "C-c C-m")
+     (cljr-add-keybindings-with-prefix "C-c C-m")
    #+end_src
 
 ** Scheme/Racket

--- a/modules/crafted-lisp.el
+++ b/modules/crafted-lisp.el
@@ -77,7 +77,7 @@
               ;; keybindings mentioned on clj-refactor github page
               ;; conflict with cider, use this by default as it does
               ;; not conflict and is a better mnemonic
-              (clj-add-keybindings-with-prefix "C-c r")))
+              (cljr-add-keybindings-with-prefix "C-c r")))
 
   (with-eval-after-load "flycheck"
     (flycheck-clojure-setup)))


### PR DESCRIPTION
This simple PR fixes a typo which prevents intended rebind from being applied.