### PR TITLE
add falback completion style

### DIFF
--- a/modules/crafted-completion.el
+++ b/modules/crafted-completion.el
@@ -81,7 +81,7 @@ ARG is the thing being completed in the minibuffer."
 
 ;; Set up Orderless for better fuzzy matching
 (require 'orderless)
-(customize-set-variable 'completion-styles '(orderless))
+(customize-set-variable 'completion-styles '(orderless basic))
 (customize-set-variable 'completion-category-overrides '((file (styles . (partial-completion)))))
 
 


### PR DESCRIPTION
This PR adds a fallback completion style as recommended by author of orderless in the [projects docs](https://github.com/oantolin/orderless/blob/6b86527b30ef96e047d97e314ac640a410891d1f/orderless.texi#L122).

It helps to solve [completion issue](https://github.com/clojure-emacs/cider/issues/3019) where namespace prefix is being ignored.

The proposed solution was found [here](https://github.com/clojure-emacs/cider/pull/3226).