### PR TITLE
Update straight.el bootstrap code

### DIFF
--- a/bootstrap/crafted-straight-bootstrap.el
+++ b/bootstrap/crafted-straight-bootstrap.el
@@ -28,14 +28,14 @@
 
 (let ((bootstrap-file
        (expand-file-name "straight/repos/straight.el/bootstrap.el" crafted-config-path))
-      (bootstrap-version 5))
+      (bootstrap-version 6))
   ;; moves the straight install directory to the users crafted
   ;; configuration folder rather than the `user-emacs-directory'
   (setq straight-base-dir crafted-config-path)
   (unless (file-exists-p bootstrap-file)
     (with-current-buffer
         (url-retrieve-synchronously
-         "https://raw.githubusercontent.com/raxod502/straight.el/develop/install.el"
+         "https://raw.githubusercontent.com/radian-software/straight.el/develop/install.el"
          'silent 'inhibit-cookies)
       (goto-char (point-max))
       (eval-print-last-sexp)))


### PR DESCRIPTION
straight.el migrated from raxod502 to the radian-software org back in May, and updated their bootstrap code from ver 5 to ver 6. This PR updates the straight.el bootstrap in the Crafted Emacs config to match.

References:
- https://github.com/radian-software/straight.el/commit/d4cd480395f3d593e1987fbe7b26b38cd4918b9c
- https://github.com/radian-software/straight.el#bootstrapping-straightel