### PR TITLE
Invoke eldoc after corfu selection

### DIFF
--- a/modules/crafted-completion.el
+++ b/modules/crafted-completion.el
@@ -111,6 +111,7 @@ ARG is the thing being completed in the minibuffer."
 (global-corfu-mode 1)
 
 (add-hook 'corfu-mode-hook #'corfu-doc-mode)
+(eldoc-add-command #'corfu-insert)
 (define-key corfu-map (kbd "M-p") #'corfu-doc-scroll-down)
 (define-key corfu-map (kbd "M-n") #'corfu-doc-scroll-up)
 (define-key corfu-map (kbd "M-d") #'corfu-doc-toggle)


### PR DESCRIPTION
Snagged this hint from [here](https://github.com/minad/corfu/issues/80#issuecomment-970588008), seemed globally applicable since `global-eldoc-mode` is `t`.