### PR TITLE
[fix-252] - add corfu extension directory to load-path

### DIFF
--- a/modules/crafted-completion.el
+++ b/modules/crafted-completion.el
@@ -99,6 +99,12 @@ ARG is the thing being completed in the minibuffer."
 
 
 ;;; Corfu
+(when (eq crafted-package-system 'straight)
+  (add-to-list 'load-
+               (expand-file-name "straight/build/corfu/extensions"
+                                 straight-base-dir)))
+(require 'corfu-popupinfo)
+
 (require 'corfu)
 ;; Setup corfu for popup like completion
 (customize-set-variable 'corfu-cycle t) ; Allows cycling through candidates

--- a/modules/crafted-completion.el
+++ b/modules/crafted-completion.el
@@ -100,7 +100,7 @@ ARG is the thing being completed in the minibuffer."
 
 ;;; Corfu
 (when (eq crafted-package-system 'straight)
-  (add-to-list 'load-
+  (add-to-list 'load-path
                (expand-file-name "straight/build/corfu/extensions"
                                  straight-base-dir)))
 (require 'corfu-popupinfo)


### PR DESCRIPTION
This PR fixes #252
Ensure that the extension directory is part of the load-path when using straight.
Explicitly loading `corfu-popupinfo` to ensure that `corfu-popupinfo-mode` is defined
