### PR TITLE
Craftedv2beta

### DIFF
--- a/bootstrap/crafted-package-bootstrap.el
+++ b/bootstrap/crafted-package-bootstrap.el
@@ -28,7 +28,7 @@
 ;; Emacs 27.x has gnu elpa as the default
 ;; Emacs 28.x adds the nongnu elpa to the list by default, so only
 ;; need to add nongnu when this isn't Emacs 28+
-(when (version< emacs-version "28")
+(when (< emacs-major-version 28)
   (add-to-list 'package-archives '("nongnu" . "https://elpa.nongnu.org/nongnu/")))
 (add-to-list 'package-archives '("stable" . "https://stable.melpa.org/packages/"))
 (add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/"))

--- a/modules/crafted-defaults-config.el
+++ b/modules/crafted-defaults-config.el
@@ -88,13 +88,13 @@ also enables undo functionality if the window layout changes."
 (customize-set-variable 'completion-category-overrides
                         '((file (styles . (partial-completion)))))
 (customize-set-variable 'completions-detailed t)
-(if (version< emacs-version "28")
+(if (< emacs-major-version 28)
     (icomplete-mode 1)
   (fido-vertical-mode 1))               ; fido-vertical-mode is
                                         ; available beginning in Emacs
                                         ; 28
 
-(when (version< emacs-version "28")
+(when (< emacs-major-version 28)
   (defun crafted-mastering-emacs-use-icomplete-vertical ()
     "Install and enable icomplete-vertical-mode for Emacs versions
 less than 28."
@@ -139,7 +139,7 @@ less than 28."
 ;; keystroke once, pressing repeated [ keys will continue paging
 ;; backward. `repeat-mode' is exited with the normal C-g, by movement
 ;; keys, typing, or pressing ESC three times.
-(unless (version< emacs-version "28")
+(unless (< emacs-major-version 28)
   (repeat-mode 1))
 
 ;; turn off forward and backward movement cycling

--- a/modules/crafted-early-init-config.el
+++ b/modules/crafted-early-init-config.el
@@ -13,7 +13,7 @@
 
 (require 'package)
 
-(when (version< emacs-version "28")
+(when (< emacs-major-version 28)
   (add-to-list 'package-archives '("nongnu" . "https://elpa.nongnu.org/nongnu/")))
 (add-to-list 'package-archives '("stable" . "https://stable.melpa.org/packages/"))
 (add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/"))

--- a/modules/crafted-evil-packages.el
+++ b/modules/crafted-evil-packages.el
@@ -17,7 +17,7 @@
 
 ;; Emacs 28+ prefer the built-in undo-redo facility, but for older
 ;; versions, undo-tree is a nice option.
-(when (< emacs-major-version "28")
+(when (< emacs-major-version 28)
   (add-to-list 'package-selected-packages 'undo-tree))
 
 (provide 'crafted-evil-packages)

--- a/modules/crafted-ide-config.el
+++ b/modules/crafted-ide-config.el
@@ -49,7 +49,7 @@ manually with something like this:
 
 ;;; tree-sitter
 ;; Emacs versions prior to 29
-(when (version< emacs-version "29")
+(when (< emacs-major-version 29)
   (when (featurep 'tree-sitter-langs)
     (require 'tree-sitter-indent nil :noerror)
 
@@ -66,7 +66,7 @@ Example: `(crafted-tree-sitter-load 'python)'"
         (add-hook mode-hook-name #'tree-sitter-mode)))))
 
 ;; Emacs versions after 29
-(when (>= (string-to-number emacs-version) 29)
+(when (>= emacs-major-version 29)
   ;; only attempt to use tree-sitter when Emacs was built with it.
   (when (and (member "TREE_SITTER" (split-string system-configuration-features))
              (executable-find "tree-sitter"))

--- a/modules/crafted-ide-packages.el
+++ b/modules/crafted-ide-packages.el
@@ -14,7 +14,7 @@
 
 ;; Add Eglot only for Emacs prior to version 29.  It is built-in since
 ;; Emacs 29.
-(when (version< emacs-version "29")
+(when (< emacs-major-version 29)
   ;; LSP capabilities
   (add-to-list 'package-selected-packages 'eglot)
 
@@ -25,7 +25,7 @@
   (add-to-list 'package-selected-packages 'tree-sitter-langs))
 
 ;; Emacs 29 packages
-(when (> (string-to-number emacs-version) 29)
+(when (> emacs-major-version 29)
   ;; automatically handles switching to tree-sitter versions of major
   ;; modes, can install grammars, etc.
   (add-to-list 'package-selected-packages 'treesit-auto)

--- a/modules/crafted-init-config.el
+++ b/modules/crafted-init-config.el
@@ -18,7 +18,7 @@
 ;; including the template below used for writing Crafted Emacs
 ;; modules.
 
-(when (version< emacs-version "29")
+(when (< emacs-major-version 29)
   ;; Get some Emacs 29 compatibility functions. Notably missing is
   ;; `setopt' which the `compat' library deliberately does not
   ;; provide, so we continue to use the `customize-set-variable'

--- a/modules/deleted-modules/crafted-erlang-packages-deprecated.el
+++ b/modules/deleted-modules/crafted-erlang-packages-deprecated.el
@@ -15,7 +15,7 @@
 (add-to-list 'package-selected-packages 'erlang)
 
 ;; Only need to install eglot if using Emacs prior to version 29.
-(unless (version< emacs-version "29")
+(unless (< emacs-major-version 29)
   (add-to-list 'package-selected-packages 'eglot))
 
 (provide 'crafted-erlang-packages)

--- a/modules/deleted-modules/crafted-mastering-emacs-config-deprecated.el
+++ b/modules/deleted-modules/crafted-mastering-emacs-config-deprecated.el
@@ -30,13 +30,13 @@
 (customize-set-variable 'completion-category-overrides
                         '((file (styles . (partial-completion)))))
 (customize-set-variable 'completions-detailed t)
-(if (version< emacs-version "28")
+(if (< emacs-major-version 28)
     (icomplete-mode 1)
   (fido-vertical-mode 1))               ; fido-vertical-mode is
                                         ; available beginning in Emacs
                                         ; 28
 
-(when (version< emacs-version "28")
+(when (< emacs-major-version 28)
   (defun crafted-mastering-emacs-use-icomplete-vertical ()
     "Install and enable icomplete-vertical-mode for Emacs versions
 less than 28."
@@ -81,7 +81,7 @@ less than 28."
 ;; keystroke once, pressing repeated [ keys will continue paging
 ;; backward. `repeat-mode' is exited with the normal C-g, by movement
 ;; keys, typing, or pressing ESC three times.
-(unless (version< emacs-version "28")
+(unless (< emacs-major-version 28)
   (repeat-mode 1))
 
 ;; turn off forward and backward movement cycling

--- a/rational2crafted.el
+++ b/rational2crafted.el
@@ -32,7 +32,7 @@
 (require 'files)
 (require 'seq)
 
-(when (version< emacs-version "28")
+(when (< emacs-major-version 28)
   ;; `string-replace' was introduced in Emacs 28. This was identified
   ;; in issue #198. This code is to support Emacs 27 users.
   (defun string-replace (from-string to-string in-string)


### PR DESCRIPTION
After trying it out with a pretty bare install from scratch (time to clean up my own config a lot) I rand into some consistency issues with the version checks for emacs in different modules. I've changed them throughout to rely on the variable `emacs-major-version`, which has been introduced at or before emacs 19.23 (so should be safe to use?).

I hope this is correct :).