### PR TITLE
Account for edge case git not found when defining crafted-emacs-home

### DIFF
--- a/modules/crafted-init-config.el
+++ b/modules/crafted-init-config.el
@@ -48,8 +48,11 @@ explicitly."))
 (when (null crafted-emacs-home)
   (setq crafted-emacs-home
         (expand-file-name
-         (project-root
-          (project-current nil (file-name-directory load-file-name))))))
+         (if (executable-find "git")
+             (project-root
+              (project-current nil (file-name-directory load-file-name)))
+           (vc-find-root load-file-name "modules")))))
+
 
 ;; update the `load-path' to include the Crafted Emacs modules path
 


### PR DESCRIPTION
Hello!

As I saw the stream today and David mentioned an [edge case](https://www.youtube.com/live/HuW4UvX1-uY?feature=share&t=3226) that I do know how to solve I thought I might contribute this rather trivial pull request to account for it. I do not use `crafted-emacs`, so I do not know for sure that this won't break anything, but I am reasonably confident that it shouldn't. I have, however, been able to test this on a system without git (via a pure `nix-shell`), and that worked just fine. Please let me know if I should change anything!