### PR TITLE
Remove org-roam from crafted-org module

### DIFF
--- a/modules/crafted-org-config.el
+++ b/modules/crafted-org-config.el
@@ -29,31 +29,5 @@
                                        `(lambda (c)
                                           (if (char-equal c ?<) t (,electric-pair-inhibit-predicate c))))))
 
-
-;;; Org Roam
-(when (featurep 'org-roam)
-  (unless (eq (custom-variable-state 'org-roam-directory nil)
-              'standard)
-    (customize-set-variable 'org-roam-directory
-                            (expand-file-name "org-roam" user-emacs-directory)))
-  ;; suggested keymap based on example from project docs
-  ;; (keymap-global-set "C-c r l" #'org-roam-buffer-toggle)
-  ;; (keymap-global-set "C-c r f" #'org-roam-node-find)
-  ;; (keymap-global-set "C-c r g" #'org-roam-graph)
-  ;; (keymap-global-set "C-c r i" #'org-roam-node-insert)
-  ;; (keymap-global-set "C-c r c" #'org-roam-capture)
-  ;; (keymap-global-set "C-c r j" . org-roam-dailies-capture-today)
-
-  ;; If you're using a vertical completion framework, you might want a
-  ;; more informative completion interface
-  (when (or (bound-and-true-p fido-vertical-mode)
-            (bound-and-true-p icomplete-vertical-mode)
-            (bound-and-true-p vertico))
-    (customize-set-variable 'org-roam-node-display-template
-                            (concat "${title:*} "
-                                    (propertize "${tags:10}" 'face 'org-tag))))
-  (org-roam-db-autosync-mode))
-
-
 (provide 'crafted-org-config)
 ;;; crafted-org-config.el ends here

--- a/modules/crafted-org-packages.el
+++ b/modules/crafted-org-packages.el
@@ -20,8 +20,5 @@
 ;; Toggle the visibility of some Org elements.
 (add-to-list 'package-selected-packages 'org-appear)
 
-;; Second brain/zettlekasten for Org Mode
-(add-to-list 'package-selected-packages 'org-roam)
-
 (provide 'crafted-org-packages)
 ;;; crafted-org-packages.el ends here


### PR DESCRIPTION
As discussed in #283.
Configuration is already moved over into documentation (see #285).