### PR TITLE
add some customization options to splash screen

### DIFF
--- a/modules/crafted-startup.el
+++ b/modules/crafted-startup.el
@@ -76,6 +76,18 @@ Each element in the list should be a list of strings or pairs
    :link `("Customize Crafted Emacs"
            ,(lambda (_button) (customize-group 'crafted))
            "Change initialization settings including this screen")
+   "\n\n"
+   :link `("Select a font style/size"
+	   ,(lambda (_button) (menu-set-font))
+	   "Change the font")
+   "     "
+   :link `("Select a theme"
+	   ,(lambda (_button) (customize-themes))
+	   "Customize the color scheme")
+   " Type 'q' to return from theme menu\n\nSave your settings => "
+   :link `("Save settings"
+	   ,(lambda (_button) (customize-save-customized))
+	   "Make Emacs yours")
    "\n")
 
   (fancy-splash-insert


### PR DESCRIPTION
Minor addition to the splash screen letting users change the theme and font right away.  Mostly for convenience, but changing the font is important for accessibility for users with high DPI screens.