### PR TITLE
[craftedv2beta] Fix crafted-screencast-config (guard, keycast-mode)

### DIFF
--- a/modules/crafted-screencast-config.el
+++ b/modules/crafted-screencast-config.el
@@ -14,7 +14,7 @@
 (when (locate-library "keycast")
   (customize-set-variable 'keycast-remove-tail-elements nil)
   (customize-set-variable 'keycast-insert-after 'mode-line-misc-info)
-  (keycast-mode))
+  (keycast-mode-line-mode))
 
 (provide 'crafted-screencast-config)
 ;;; crafted-screencast.el ends here

--- a/modules/crafted-screencast-config.el
+++ b/modules/crafted-screencast-config.el
@@ -11,7 +11,7 @@
 
 ;;; Code:
 
-(when (featurep 'keycast)
+(when (locate-library "keycast")
   (customize-set-variable 'keycast-remove-tail-elements nil)
   (customize-set-variable 'keycast-insert-after 'mode-line-misc-info)
   (keycast-mode))


### PR DESCRIPTION
Fixes both the guard (`featurep` ~> `locate-library`) and mode activation (`keycast-mode` ~> `keycast-mode-line-mode`, see #262) in crafted-screencast-config.

Now loading the crafted-screencast modules automatically enables the keys being shown in the modeline.
Put both in one PR because I had to change the guard to test the mode working anyway.
Ready for review/merge.