### PR TITLE
[craftedv2beta] Fix electric-pair-inhibit-predicate in crafted-org

### DIFF
--- a/docs/crafted-emacs.info
+++ b/docs/crafted-emacs.info
@@ -1077,11 +1077,12 @@ enhance the experience.
 
      Hides emphasis markers like ‘*bold*’ or ‘=highlighted=’.
 
-   • New ‘org-mode-hook’:
+   • New ‘org-mode-hook’ and ‘electric-pair-mode-hook’:
 
-     Adding a hook to org-mode setting the local
+     Adding a hook to setting the local
      ‘electric-pair-inhibit-predicate’ value to ignore ‘<’ for
-     auto-pairing.
+     auto-pairing.  It is attached to both hooks to ensure the predicate
+     is set up properly no matter which order the mode-hooks are run.
 
    • ‘Package: denote’
 
@@ -1304,10 +1305,10 @@ Node: Description (1)37207
 Node: Crafted Emacs Org Module37890
 Node: Installation (2)38173
 Node: Description (2)38675
-Node: Alternative package org-roam40543
-Node: Troubleshooting42347
-Node: A package (suddenly?) fails to work42583
-Node: MIT License46371
+Node: Alternative package org-roam40692
+Node: Troubleshooting42496
+Node: A package (suddenly?) fails to work42732
+Node: MIT License46520
 
 End Tag Table
 

--- a/docs/crafted-org.org
+++ b/docs/crafted-org.org
@@ -43,10 +43,12 @@ experience.
 
   Hides emphasis markers like =*bold*= or ==highlighted==.
 
-- New =org-mode-hook=:
+- New =org-mode-hook= and =electric-pair-mode-hook=:
 
-  Adding a hook to org-mode setting the local
-  =electric-pair-inhibit-predicate= value to ignore =<= for auto-pairing.
+  Adding a hook to setting the local =electric-pair-inhibit-predicate=
+  value to ignore =<= for auto-pairing.
+  It is attached to both hooks to ensure the predicate is set up properly
+  no matter which order the mode-hooks are run.
 
 - =Package: denote=
 

--- a/modules/crafted-org-config.el
+++ b/modules/crafted-org-config.el
@@ -26,11 +26,21 @@
 (when (featurep 'org-appear)
   (add-hook 'org-mode-hook 'org-appear-mode))
 
-;; Disable auto-pairing of "<" in org-mode
-(add-hook 'org-mode-hook (lambda ()
-                           (setq-local electric-pair-inhibit-predicate
-                                       `(lambda (c)
-                                          (if (char-equal c ?<) t (,electric-pair-inhibit-predicate c))))))
+;; Disable auto-pairing of "<" in org-mode with electric-pair-mode
+(defun crafted-org/enhance-electric-pair-inhibit-predicate ()
+  "Disable auto-pairing of \"<\" in `org-mode' when using `electric-pair-mode'."
+  (when (and electric-pair-mode (eql major-mode #'org-mode))
+    (setq-local electric-pair-inhibit-predicate
+                `(lambda (c)
+                   (if (char-equal c ?<)
+                       t
+                     (,electric-pair-inhibit-predicate c))))))
+
+;; Add hook to both electric-pair-mode-hook and org-mode-hook
+;; This ensures org-mode buffers don't behave weirdly,
+;; no matter when electric-pair-mode is activated.
+(add-hook 'electric-pair-mode-hook #'crafted-org/enhance-electric-pair-inhibit-predicate)
+(add-hook 'org-mode-hook #'crafted-org/enhance-electric-pair-inhibit-predicate)
 
 (provide 'crafted-org-config)
 ;;; crafted-org-config.el ends here


### PR DESCRIPTION
Addresses #295 (and partially #280) by implementing a fix to check modes are enabled.

Added to both mode-hooks to ensure the order of activation for `org-mode` and `electric-pair-mode` is irrelevant for producing the effect (setting the buffer-local variable).

Documentation is updated (info buffer regenerated).

Ready for review/merge.