### PR TITLE
[craftedv2beta] `locate-library`-guard for `crafted-org-config`

### DIFF
--- a/modules/crafted-org-config.el
+++ b/modules/crafted-org-config.el
@@ -23,7 +23,7 @@
 
 ;; Hide markup markers
 (customize-set-variable 'org-hide-emphasis-markers t)
-(when (featurep 'org-appear)
+(when (locate-library "org-appear")
   (add-hook 'org-mode-hook 'org-appear-mode))
 
 ;; Disable auto-pairing of "<" in org-mode with electric-pair-mode


### PR DESCRIPTION
As discussed in #313 .

I had a thought, though: When it's only a question of whether a mode is available or not (as in this case), wouldn't `fboundp` be more efficient? And the more canonical way to do this?

```elisp
(when (fboundp 'org-appear-mode)
  (add-hook 'org-mode-hook 'org-appear-mode))
```

I like the simplicity of using a `require`-guard if we require anyway and using `locate-library` for anything else, but a case like this made me wonder.

Any thoughts?