### PR TITLE
string-match-guards for crafted-init-config

### DIFF
--- a/modules/crafted-init-config.el
+++ b/modules/crafted-init-config.el
@@ -82,7 +82,8 @@ explicitly."))
     "Apply ORIG-AUTO-INSERT only when the file is not the
 `custom-file' to avoid confusion when that file doesn't exist on
 startup."
-    (if (string-match (file-name-nondirectory custom-file) buffer-file-name)
+    (if (and custom-file buffer-file-name
+             (string-match (file-name-nondirectory custom-file) buffer-file-name))
         (message "Skipping auto-insert for %s" custom-file)
       (apply orig-auto-insert args)))
   (advice-add 'auto-insert :around #'ignore-auto-insert-for-custom)


### PR DESCRIPTION
The functionality for ignoring the auto-insert on the custom file may run into an issue 
when the `custom-file` and/or `file-buffer-name` values are `nil`.

This essentially breaks the `auto-insert` function for non-file buffers  (and all buffers 
if `custom-file` is `nil`).