### PR TITLE
Make named functions for hooks

### DIFF
--- a/examples/init-example.el
+++ b/examples/init-example.el
@@ -49,10 +49,11 @@
 ;;; Optional configuration
 
 ;; Profile emacs startup
-(add-hook 'emacs-startup-hook
-          (lambda ()
-            (message "Crafted Emacs loaded in %s."
-                     (emacs-init-time))))
+(defun crafted-startup-example/display-startup-time ()
+  "Display the startup time after Emacs is fully initialized."
+  (message "Crafted Emacs loaded in %s."
+           (emacs-init-time)))
+(add-hook 'emacs-startup-hook #'crafted-startup-example/display-startup-time)
 
 ;; Set default coding system (especially for Windows)
 (set-default-coding-systems 'utf-8)

--- a/modules/crafted-completion-config.el
+++ b/modules/crafted-completion-config.el
@@ -136,11 +136,15 @@ ARG is the thing being completed in the minibuffer."
   ;; Ensure that pcomplete does not write to the buffer
   ;; and behaves as a pure `completion-at-point-function'.
   (advice-add 'pcomplete-completions-at-point :around #'cape-wrap-purify)
-  (add-hook 'eshell-mode-hook
-            (lambda () (setq-local corfu-quit-at-boundary t
-                                   corfu-quit-no-match t
-                                   corfu-auto nil)
-              (corfu-mode))))
+
+  ;; No auto-completion or completion-on-quit in eshell
+  (defun crafted-completion/corfu-eshell ()
+    "Special settings for when using corfu with eshell."
+    (setq-local corfu-quit-at-boundary t
+                corfu-quit-no-match t
+                corfu-auto nil)
+    (corfu-mode))
+  (add-hook 'eshell-mode-hook #'crafted-completion/corfu-eshell))
 
 (provide 'crafted-completion-config)
 ;;; crafted-completion.el ends here

--- a/modules/crafted-ide-config.el
+++ b/modules/crafted-ide-config.el
@@ -93,11 +93,12 @@ Example: `(crafted-tree-sitter-load 'python)'"
 
 ;; enhance ibuffer with ibuffer-project if it is available.
 (when (require 'ibuffer-project nil :noerror)
-  (add-hook 'ibuffer-hook
-            (lambda ()
-              (setq ibuffer-filter-groups (ibuffer-project-generate-filter-groups))
-              (unless (eq ibuffer-sorting-mode 'project-file-relative)
-                (ibuffer-do-sort-by-project-file-relative)))))
+  (defun crafted-ide/enhance-ibuffer-with-ibuffer-project ()
+    "Set up integration for `ibuffer' with `ibuffer-project'."
+    (setq ibuffer-filter-groups (ibuffer-project-generate-filter-groups))
+    (unless (eq ibuffer-sorting-mode 'project-file-relative)
+      (ibuffer-do-sort-by-project-file-relative)))
+  (add-hook 'ibuffer-hook #'crafted-ide/enhance-ibuffer-with-ibuffer-project))
 
 (provide 'crafted-ide-config)
 ;;; crafted-ide-config.el ends here

--- a/modules/crafted-lisp-config.el
+++ b/modules/crafted-lisp-config.el
@@ -54,9 +54,6 @@
 (when (featurep 'sly)
   (add-hook 'lisp-mode-hook #'sly-editing-mode))
 
-(when (featurep 'aggressive-indent-mode)
-  (add-hook 'lisp-mode-hook #'aggressive-indent-mode))
-
 
 ;;; Clojure
 (with-eval-after-load "clojure-mode"
@@ -76,18 +73,19 @@
   (with-eval-after-load "flycheck"
     (flycheck-clojure-setup)))
 
-(when (featurep 'aggressive-indent-mode)
-  (add-hook 'clojure-mode-hook #'aggressive-indent-mode))
-
 
 ;;; Scheme and Racket
-(when (featurep 'aggressive-indent-mode)
-  (add-hook 'scheme-mode-hook #'aggressive-indent-mode))
-
 ;; The default is "scheme" which is used by cmuscheme, xscheme and
 ;; chez (at least). We are configuring guile, so use the apporpriate
 ;; command for that implementation.
 (customize-set-variable 'scheme-program-name "guile")
+
+
+;;; Aggressive Indent Mode for all Lisp Modes
+(when (locate-lbirary "aggressive-indent")
+  (add-hook 'lisp-mode-hook #'aggressive-indent-mode)
+  (add-hook 'clojure-mode-hook #'aggressive-indent-mode)
+  (add-hook 'scheme-mode-hook #'aggressive-indent-mode))
 
 
 (provide 'crafted-lisp-config)

--- a/modules/crafted-lisp-config.el
+++ b/modules/crafted-lisp-config.el
@@ -62,14 +62,16 @@
 (with-eval-after-load "clojure-mode"
   (require 'cider "cider" :no-error)
   (require 'clj-refactor "clj-refactor" :no-error)
-  (add-hook 'clojure-mode-hook
-            (lambda ()
-              (when (featurep 'clj-refactor)
-                (clj-refactor-mode 1)
-                ;; keybindings mentioned on clj-refactor github page
-                ;; conflict with cider, use this by default as it does
-                ;; not conflict and is a better mnemonic
-                (cljr-add-keybindings-with-prefix "C-c r"))))
+
+  (defun crafted-lisp/load-clojure-refactor ()
+    "Load `clj-refactor' toooling and fix keybinding conflicts with cider."
+    (when (featurep 'clj-refactor)
+      (clj-refactor-mode 1)
+      ;; keybindings mentioned on clj-refactor github page
+      ;; conflict with cider, use this by default as it does
+      ;; not conflict and is a better mnemonic
+      (cljr-add-keybindings-with-prefix "C-c r")))
+  (add-hook 'clojure-mode-hook #'crafted-lisp/load-clojure-refactor)
 
   (with-eval-after-load "flycheck"
     (flycheck-clojure-setup)))

--- a/modules/crafted-writing-config.el
+++ b/modules/crafted-writing-config.el
@@ -141,10 +141,11 @@ Depends on having `pdf-tools' installed.  See
     (customize-save-variable 'TeX-source-correlate-start-server t)))
 
 ;; message the user if the latex executable is not found
-(add-hook 'tex-mode-hook
-          #'(lambda ()
-              (unless (executable-find "latex")
-                (message "latex executable not found"))))
+(defun crafted-writing/tex-warning-if-no-latex-executable ()
+  "Print a message to the minibuffer if the \"latex\" executable cannot be found."
+  (unless (executable-find "latex")
+    (message "latex executable not found")))
+(add-hook 'tex-mode-hook #'crafted-writing/tex-warning-if-no-latex-executable)
 
 (when (and (executable-find "latex")
            (executable-find "latexmk"))
@@ -153,7 +154,11 @@ Depends on having `pdf-tools' installed.  See
       (with-eval-after-load 'auctex-latexmk
         (auctex-latexmk-setup)
         (customize-save-variable 'auctex-latexmk-inherit-TeX-PDF-mode t))
-      (add-hook 'TeX-mode-hook #'(lambda () (setq TeX-command-default "LatexMk"))))))
+
+      (defun crafted-writing/tex-make-latexmk-default-command ()
+        "Set `TeX-command-default' to \"LatexMk\"."
+        (setq TeX-command-default "LatexMk"))
+      (add-hook 'TeX-mode-hook #'crafted-writing/tex-make-latexmk-default-command))))
 
 
 ;;; Markdown
@@ -177,9 +182,10 @@ Depends on having `pdf-tools' installed.  See
 
 ;;; PDF Support when using pdf-tools
 (when (featurep 'pdf-tools)
-  (add-hook 'doc-view-mode-hook
-            (lambda ()
-              (require 'pdf-tools nil :noerror)))
+  (defun crafted-writing/load-pdf-tools ()
+    "Attempts to require pdf-tools, but for attaching to hooks."
+    (require 'pdf-tools nil :noerror))
+  (add-hook 'doc-view-mode-hook #'crafted-writing/load-pdf-tools)
 
   (with-eval-after-load 'pdf-tools
     (pdf-tools-install)


### PR DESCRIPTION
Addresses #280.

Pulls out functionality into named functions for:
- `crafted-writing-config`
- `crafted-ide-config`
- `crafted-lisp-config`
- `crafted-completion-config`
- `init-example`

Should not alter functionality, but the sections now comply with the style guide.
