### PR TITLE
[craftedv2beta] Fix guards for `crafted-lisp` module

### DIFF
--- a/modules/crafted-lisp-config.el
+++ b/modules/crafted-lisp-config.el
@@ -57,7 +57,7 @@
   (require 'sly-repl-ansi-color "sly-repl-ansi-color" :no-error)
   (require 'sly-asdf "sly-asdf" :no-error))
 
-(when (featurep 'sly)
+(when (locate-library "sly")
   (add-hook 'lisp-mode-hook #'sly-editing-mode))
 
 
@@ -68,7 +68,7 @@
 
   (defun crafted-lisp/load-clojure-refactor ()
     "Load `clj-refactor' toooling and fix keybinding conflicts with cider."
-    (when (featurep 'clj-refactor)
+    (when (locate-library "clj-refactor")
       (clj-refactor-mode 1)
       ;; keybindings mentioned on clj-refactor github page
       ;; conflict with cider, use this by default as it does

--- a/modules/crafted-lisp-config.el
+++ b/modules/crafted-lisp-config.el
@@ -38,6 +38,12 @@
 ;; Global defaults
 (require 'eldoc)
 
+;; aggressive-indent-mode for all lisp modes
+(when (locate-library "aggressive-indent")
+  (add-hook 'lisp-mode-hook #'aggressive-indent-mode)
+  (add-hook 'clojure-mode-hook #'aggressive-indent-mode)
+  (add-hook 'scheme-mode-hook #'aggressive-indent-mode))
+
 
 ;;; Common Lisp
 
@@ -53,9 +59,6 @@
 
 (when (featurep 'sly)
   (add-hook 'lisp-mode-hook #'sly-editing-mode))
-
-(when (featurep 'aggressive-indent-mode)
-  (add-hook 'lisp-mode-hook #'aggressive-indent-mode))
 
 
 ;;; Clojure
@@ -76,14 +79,8 @@
   (with-eval-after-load "flycheck"
     (flycheck-clojure-setup)))
 
-(when (featurep 'aggressive-indent-mode)
-  (add-hook 'clojure-mode-hook #'aggressive-indent-mode))
-
 
 ;;; Scheme and Racket
-(when (featurep 'aggressive-indent-mode)
-  (add-hook 'scheme-mode-hook #'aggressive-indent-mode))
-
 ;; The default is "scheme" which is used by cmuscheme, xscheme and
 ;; chez (at least). We are configuring guile, so use the apporpriate
 ;; command for that implementation.


### PR DESCRIPTION
Fixes `featurep` guards for `crafted-lisp` module.
I also moved all the code for `aggressive-indent` into the top section as it's all related, so we don't have to re-check in every section.

Ready for review/merge.