### PR TITLE
[craftedv2beta] Add option to opt out of saving customizations every session.

### DIFF
--- a/modules/crafted-init-config.el
+++ b/modules/crafted-init-config.el
@@ -18,6 +18,27 @@
 ;; including the template below used for writing Crafted Emacs
 ;; modules.
 
+(defgroup crafted-init '()
+  "Initialization configuration for Crafted Emacs"
+  :tag "Crafted Init"
+  :group 'crafted)
+
+;; By default, crafted emacs calls `customize-save-variable' in the
+;; `after-init-hook'. The user can opt out of this by setting
+;; `crafted-init-auto-save-customized' to nil.
+(defcustom crafted-init-auto-save-customized t
+  "Save customized variables automatically every session."
+  :type 'boolean
+  :group 'crafted-init)
+
+;; By default, crafted emacs calls `package--save-selected-packages' in the
+;; `after-init-hook'. The user can opt out of this by setting
+;; `crafted-init-auto-save-selected-packages' to nil.
+(defcustom crafted-init-auto-save-selected-packages t
+  "Save the list of selected packages automatically every session."
+  :type 'boolean
+  :group 'crafted-init)
+
 (when (version< emacs-version "29")
   ;; Get some Emacs 29 compatibility functions. Notably missing is
   ;; `setopt' which the `compat' library deliberately does not
@@ -119,9 +140,11 @@ startup."
     (info-initialize)
     (push (file-name-directory crafted-info-dir) Info-directory-list)))
 
-;; Save all customizations to `custom-file'
-(add-hook 'after-init-hook #'customize-save-customized)
-(add-hook 'after-init-hook #'package--save-selected-packages)
+;; Save all customizations to `custom-file', unless the user opted out.
+(when crafted-init-auto-save-customized
+  (add-hook 'after-init-hook #'customize-save-customized))
+(when crafted-init-auto-save-selected-packages
+  (add-hook 'after-init-hook #'package--save-selected-packages))
 
 (provide 'crafted-init-config)
 ;;; crafted-init-config.el ends here


### PR DESCRIPTION
As we discussed in #324, the calls to `customize-save-customized` and `package--save-selected-packages` in the `after-init-hook` should be the default behaviour. This adds the possibility for users to opt out of that without having to maintain a custom branch of Crafted Emacs.

It 
- introduces a new customization group "Crafted Init"
- introduces two new variables in that group:
  1. `crafted-init-auto-save-customized`
  2. `crafted-init-auto-save-selected-packages`

By default, they are non-nil. Setting them to nil will prevent `customize-save-customized` and `package--save-selected-packages` to be added to `after-init-hook` respectively.