### PR TITLE
[craftedv2beta] Simplify path construction for auto-insert of CE header

### DIFF
--- a/modules/crafted-init-config.el
+++ b/modules/crafted-init-config.el
@@ -109,7 +109,7 @@ startup."
       (apply orig-auto-insert args)))
   (advice-add 'auto-insert :around #'ignore-auto-insert-for-custom)
   (define-auto-insert
-    (cons (concat (expand-file-name crafted-emacs-home) "modules/crafted-.*\\.el")
+    (cons (expand-file-name "modules/crafted-.*\\.el" crafted-emacs-home)
           "Crafted Emacs Lisp Skeleton")
     '("Crafted Emacs Module Description: "
       ";;;; " (file-name-nondirectory (buffer-file-name)) " --- " str


### PR DESCRIPTION
Small potential bug I found while reading into the skeleton discussion.

Replacing
```emacs-lisp
(concat (expand-file-name crafted-emacs-home) "modules/crafted-.*\\.el")
```
with
```emacs-lisp
(expand-file-name "modules/crafted-.*\\.el" crafted-emacs-home)
```

Just a bit "cleaner".
Not sure if it's technically a bug-fix, but if `crafted-emacs-home` had no trailing "/", the previous version would not account for it and produce an invalid path.
