### PR TITLE
Fix config guard for treesit-auto

### DIFF
--- a/modules/crafted-ide-config.el
+++ b/modules/crafted-ide-config.el
@@ -69,7 +69,7 @@ Example: `(crafted-tree-sitter-load 'python)'"
   ;; only attempt to use tree-sitter when Emacs was built with it.
   (when (and (member "TREE_SITTER" (split-string system-configuration-features))
              (executable-find "tree-sitter"))
-    (when (locate-library "treesit-auto")
+    (when (require 'treesit-auto nil :noerror)
       ;; prefer tree-sitter modes
       (global-treesit-auto-mode)
       (with-eval-after-load 'treesit-auto


### PR DESCRIPTION
treesit-auto was using locate-library, but should have been using the require guard instead.