### PR TITLE
Update osx module, remove bad assumptions and failing code

### DIFF
--- a/modules/crafted-osx-config.el
+++ b/modules/crafted-osx-config.el
@@ -16,10 +16,8 @@
 (defun crafted-osx-transparent-titlebar ()
   "Set the titlebar to be transparent."
   (interactive)
-  (customize-set-variable frame-resize-pixelwise t)
-  (add-to-list 'default-frame-alist '(ns-transparent-titlebar . t))
-  (add-to-list 'default-frame-alist '(selected-frame) 'name nil)
-  (add-to-list 'default-frame-alist '(ns-appearance . dark))) ;; assuming a dark theme is in use
+  (customize-set-variable 'frame-resize-pixelwise t)
+  (add-to-list 'default-frame-alist '(ns-transparent-titlebar . t)))
 
 ;; Special keys
 (when (featurep 'ns)


### PR DESCRIPTION
Removed an assumption a dark theme was being used, also there seemed to be some attempt at setting the name of the selected frame to nil, it didn't work and not sure that makes any sense anyway.