### PR TITLE
[craftedv2beta] Bundle evil keybindings into `crafted-evil-config`

### DIFF
--- a/modules/crafted-completion-config.el
+++ b/modules/crafted-completion-config.el
@@ -36,13 +36,6 @@ ARG is the thing being completed in the minibuffer."
   ;; Start Vertico
   (vertico-mode 1)
 
-  ;; configure keys for those who prefer vi keybindings
-  (when (featurep 'evil)
-    (with-eval-after-load 'evil
-      (keymap-set vertico-map "C-j" 'vertico-next)
-      (keymap-set vertico-map "C-k" 'vertico-previous)
-      (keymap-set vertico-map "M-h" 'vertico-directory-up)))
-
   ;; Turn off the built-in fido-vertical-mode and icomplete-vertical-mode, if
   ;; they have been turned on by crafted-defaults-config, because they interfere
   ;; with this module.

--- a/modules/crafted-evil-config.el
+++ b/modules/crafted-evil-config.el
@@ -81,7 +81,29 @@ Rebinds the arrow keys to display a message instead."
                 term-mode))
   (add-to-list 'evil-emacs-state-modes mode))
 
-(evil-collection-init)
+;;; evil-collection or some crafted defaults
+(if (locate-library "evil-collection")
+    ;; if the user has `evil-collection' installed, let it take care of
+    ;; keybindings
+    (evil-collection-init)
+  ;; Otherwise load up a few keybindings for other crafted modules
+  ;; as needed
+  ((with-eval-after-load 'crafted-completion-config
+     (when (featurep 'vertico) ;; only if the user actually uses vertico
+       (keymap-set vertico-map "C-j" 'vertico-next)
+       (keymap-set vertico-map "C-k" 'vertico-previous)
+       (keymap-set vertico-map "M-h" 'vertico-directory-up)))
+
+   (with-eval-after-load 'crafted-speedbar-config
+     ;;edit/open file under point
+     (keymap-set speedbar-mode-map "<return>" 'speedbar-edit-line)
+     ;;toggle thing at point
+     (keymap-set speedbar-mode-map "<tab>" 'speedbar-toggle-line-expansion)
+     ;;evaluate as elisp if file at point is elisp, I dont use this too much but might be useful
+     (keymap-set speedbar-mode-map "L" 'speedbar-item-load)
+     ;;temporarly change mode in speedbar to "buffer-switching mode".
+     ;;useful for quickly switching to an open buffer
+     (keymap-set speedbar-mode-map "b" 'speedbar-switch-to-quick-buffers))))
 
 (provide 'crafted-evil-config)
 ;;; crafted-evil-config.el ends here

--- a/modules/crafted-speedbar-config.el
+++ b/modules/crafted-speedbar-config.el
@@ -26,24 +26,6 @@
   (interactive)
   (speedbar-change-initial-expansion-list "quick buffers"))
 
-
-;;; Keybindings:
-;;;; evil-mode adjustments
-(with-eval-after-load 'speedbar
-  (with-eval-after-load 'evil
-    ;;edit/open file under point
-    (keymap-set speedbar-mode-map "<return>" 'speedbar-edit-line)
-    ;;toggle thing at point
-    (keymap-set speedbar-mode-map "<tab>" 'speedbar-toggle-line-expansion)
-    ;;evaluate as elisp if file at point is elisp, I dont use this too much but might be useful
-    (keymap-set speedbar-mode-map "C-<return>" 'speedbar-item-load)
-    ;;temporarly change mode in speedbar to "buffer-switching mode".
-    ;;useful for quickly switching to an open buffer
-    (keymap-set speedbar-mode-map "b" 'speedbar-switch-to-quick-buffers)))
-
-(with-eval-after-load 'evil-collection
-  (evil-collection-speedbar-setup))
-
 ;;; Set some sane defaults, can be easily extended by user.
 (setq-default speedbar-frame-parameters
               '((name . "speedbar")


### PR DESCRIPTION
Load them only if `evil-collection` is not used.