### PR TITLE
[craftedv2beta] Overhaul crafted-speedbar module

### DIFF
--- a/docs/crafted-emacs.info
+++ b/docs/crafted-emacs.info
@@ -1856,7 +1856,8 @@ enhance the experience.
    • ‘Package: evil-collection’
 
      vim-like bindings for modes not covered by the ‘evil’ package.
-     Automatically initialized for all common modes and ‘speedbar’.
+     Automatically initialized for all common modes (see
+     ‘evil-collection-mode-list’).
 
    • ‘Package: evil-nerd-commenter’
 
@@ -2983,59 +2984,59 @@ Node: Acknowledgements67243
 Node: Crafted Emacs Evil Module67766
 Node: Installation (2)68050
 Node: Description (2)68557
-Node: Crafted Emacs IDE Module71756
-Node: Installation (3)72034
-Node: Description (3)72536
-Ref: Eglot73394
-Ref: Tree-Sitter73844
-Ref: Combobulate74047
-Node: Crafted Emacs Lisp Module74856
-Node: Installation (4)75168
-Node: Description (4)75675
-Ref: Common Lisp76269
-Ref: Clojure77135
-Ref: Scheme and Racket77771
-Node: Additional packages geiser-*78367
-Node: Crafted Emacs Org Module79421
-Node: Installation (5)79738
-Node: Description (5)80240
-Node: Alternative package org-roam82257
-Node: Crafted Emacs Screencast Module84061
-Node: Installation (6)84362
-Node: Description (6)84899
-Node: Crafted Emacs Startup Module85582
-Node: Installation (7)85876
-Node: Description (7)86344
-Node: Crafted Emacs UI Module87754
-Node: Installation (8)88035
-Node: Description (8)88532
-Ref: Icons with all-the-icons89199
-Ref: Line numbers89714
-Node: Crafted Emacs Updates Module91005
-Node: Installation (9)91301
-Node: Description (9)91771
-Ref: Usage and Customization92349
-Ref: On Startup92500
-Ref: Regularly93211
-Ref: Manually94138
-Node: Crafted Emacs Workspaces Module94741
-Node: Installation (10)95050
-Node: Description (10)95591
-Node: Crafted Emacs Writing Module97144
-Node: Installation (11)97410
-Node: Description (11)97936
-Ref: Whitespace Mode98463
-Ref: Function `crafted-writing-configure-whitespace`98929
-Ref: Signature98997
-Ref: Parameters99164
-Ref: Examples100073
-Ref: Optional Package PDF-Tools101182
-Ref: Part 1 Installing the Emacs package pdf-tools101528
-Ref: Part 2 Installing the epdfinfo-server101946
-Ref: Configuration102668
-Node: Troubleshooting103150
-Node: A package (suddenly?) fails to work103386
-Node: MIT License107174
+Node: Crafted Emacs IDE Module71780
+Node: Installation (3)72058
+Node: Description (3)72560
+Ref: Eglot73418
+Ref: Tree-Sitter73868
+Ref: Combobulate74071
+Node: Crafted Emacs Lisp Module74880
+Node: Installation (4)75192
+Node: Description (4)75699
+Ref: Common Lisp76293
+Ref: Clojure77159
+Ref: Scheme and Racket77795
+Node: Additional packages geiser-*78391
+Node: Crafted Emacs Org Module79445
+Node: Installation (5)79762
+Node: Description (5)80264
+Node: Alternative package org-roam82281
+Node: Crafted Emacs Screencast Module84085
+Node: Installation (6)84386
+Node: Description (6)84923
+Node: Crafted Emacs Startup Module85606
+Node: Installation (7)85900
+Node: Description (7)86368
+Node: Crafted Emacs UI Module87778
+Node: Installation (8)88059
+Node: Description (8)88556
+Ref: Icons with all-the-icons89223
+Ref: Line numbers89738
+Node: Crafted Emacs Updates Module91029
+Node: Installation (9)91325
+Node: Description (9)91795
+Ref: Usage and Customization92373
+Ref: On Startup92524
+Ref: Regularly93235
+Ref: Manually94162
+Node: Crafted Emacs Workspaces Module94765
+Node: Installation (10)95074
+Node: Description (10)95615
+Node: Crafted Emacs Writing Module97168
+Node: Installation (11)97434
+Node: Description (11)97960
+Ref: Whitespace Mode98487
+Ref: Function `crafted-writing-configure-whitespace`98953
+Ref: Signature99021
+Ref: Parameters99188
+Ref: Examples100097
+Ref: Optional Package PDF-Tools101206
+Ref: Part 1 Installing the Emacs package pdf-tools101552
+Ref: Part 2 Installing the epdfinfo-server101970
+Ref: Configuration102692
+Node: Troubleshooting103174
+Node: A package (suddenly?) fails to work103410
+Node: MIT License107198
 
 End Tag Table
 

--- a/docs/crafted-emacs.info
+++ b/docs/crafted-emacs.info
@@ -1372,7 +1372,8 @@ File: crafted-emacs.info,  Node: Completion,  Next: Editing,  Prev: Buffers,  Up
           package ‘vertico’ installed, all of these modes will be turned
           off in favour of ‘vertico’.
 
-The following settings will apply, no matter which completion modeyou use.
+   The following settings will apply, no matter which completion mode
+you use.
 
    • ‘tab-always-indent’ : ‘complete’
 
@@ -1855,6 +1856,7 @@ enhance the experience.
    • ‘Package: evil-collection’
 
      vim-like bindings for modes not covered by the ‘evil’ package.
+     Automatically initialized for all common modes and ‘speedbar’.
 
    • ‘Package: evil-nerd-commenter’
 
@@ -2981,59 +2983,59 @@ Node: Acknowledgements67243
 Node: Crafted Emacs Evil Module67766
 Node: Installation (2)68050
 Node: Description (2)68557
-Node: Crafted Emacs IDE Module71684
-Node: Installation (3)71962
-Node: Description (3)72464
-Ref: Eglot73322
-Ref: Tree-Sitter73772
-Ref: Combobulate73975
-Node: Crafted Emacs Lisp Module74784
-Node: Installation (4)75096
-Node: Description (4)75603
-Ref: Common Lisp76197
-Ref: Clojure77063
-Ref: Scheme and Racket77699
-Node: Additional packages geiser-*78295
-Node: Crafted Emacs Org Module79349
-Node: Installation (5)79666
-Node: Description (5)80168
-Node: Alternative package org-roam82185
-Node: Crafted Emacs Screencast Module83989
-Node: Installation (6)84290
-Node: Description (6)84827
-Node: Crafted Emacs Startup Module85510
-Node: Installation (7)85804
-Node: Description (7)86272
-Node: Crafted Emacs UI Module87682
-Node: Installation (8)87963
-Node: Description (8)88460
-Ref: Icons with all-the-icons89127
-Ref: Line numbers89642
-Node: Crafted Emacs Updates Module90933
-Node: Installation (9)91229
-Node: Description (9)91699
-Ref: Usage and Customization92277
-Ref: On Startup92428
-Ref: Regularly93139
-Ref: Manually94066
-Node: Crafted Emacs Workspaces Module94669
-Node: Installation (10)94978
-Node: Description (10)95519
-Node: Crafted Emacs Writing Module97072
-Node: Installation (11)97338
-Node: Description (11)97864
-Ref: Whitespace Mode98391
-Ref: Function `crafted-writing-configure-whitespace`98857
-Ref: Signature98925
-Ref: Parameters99092
-Ref: Examples100001
-Ref: Optional Package PDF-Tools101110
-Ref: Part 1 Installing the Emacs package pdf-tools101456
-Ref: Part 2 Installing the epdfinfo-server101874
-Ref: Configuration102596
-Node: Troubleshooting103078
-Node: A package (suddenly?) fails to work103314
-Node: MIT License107102
+Node: Crafted Emacs IDE Module71756
+Node: Installation (3)72034
+Node: Description (3)72536
+Ref: Eglot73394
+Ref: Tree-Sitter73844
+Ref: Combobulate74047
+Node: Crafted Emacs Lisp Module74856
+Node: Installation (4)75168
+Node: Description (4)75675
+Ref: Common Lisp76269
+Ref: Clojure77135
+Ref: Scheme and Racket77771
+Node: Additional packages geiser-*78367
+Node: Crafted Emacs Org Module79421
+Node: Installation (5)79738
+Node: Description (5)80240
+Node: Alternative package org-roam82257
+Node: Crafted Emacs Screencast Module84061
+Node: Installation (6)84362
+Node: Description (6)84899
+Node: Crafted Emacs Startup Module85582
+Node: Installation (7)85876
+Node: Description (7)86344
+Node: Crafted Emacs UI Module87754
+Node: Installation (8)88035
+Node: Description (8)88532
+Ref: Icons with all-the-icons89199
+Ref: Line numbers89714
+Node: Crafted Emacs Updates Module91005
+Node: Installation (9)91301
+Node: Description (9)91771
+Ref: Usage and Customization92349
+Ref: On Startup92500
+Ref: Regularly93211
+Ref: Manually94138
+Node: Crafted Emacs Workspaces Module94741
+Node: Installation (10)95050
+Node: Description (10)95591
+Node: Crafted Emacs Writing Module97144
+Node: Installation (11)97410
+Node: Description (11)97936
+Ref: Whitespace Mode98463
+Ref: Function `crafted-writing-configure-whitespace`98929
+Ref: Signature98997
+Ref: Parameters99164
+Ref: Examples100073
+Ref: Optional Package PDF-Tools101182
+Ref: Part 1 Installing the Emacs package pdf-tools101528
+Ref: Part 2 Installing the epdfinfo-server101946
+Ref: Configuration102668
+Node: Troubleshooting103150
+Node: A package (suddenly?) fails to work103386
+Node: MIT License107174
 
 End Tag Table
 

--- a/docs/crafted-evil.org
+++ b/docs/crafted-evil.org
@@ -30,7 +30,8 @@ the experience.
 - =Package: evil-collection=
 
   vim-like bindings for modes not covered by the ~evil~ package.
-  Automatically initialized for all common modes and ~speedbar~.
+  Automatically initialized for all common modes
+  (see ~evil-collection-mode-list~).
 
 - =Package: evil-nerd-commenter=
 

--- a/docs/crafted-evil.org
+++ b/docs/crafted-evil.org
@@ -30,6 +30,7 @@ the experience.
 - =Package: evil-collection=
 
   vim-like bindings for modes not covered by the ~evil~ package.
+  Automatically initialized for all common modes and ~speedbar~.
 
 - =Package: evil-nerd-commenter=
 

--- a/modules/crafted-evil-config.el
+++ b/modules/crafted-evil-config.el
@@ -83,11 +83,7 @@ Rebinds the arrow keys to display a message instead."
 
 (when (locate-library "evil-collection")
   ;; Initialize evil-collection
-  (evil-collection-init)
-
-  ;; If speedbar is loaded, run evil-collection setup
-  (with-eval-after-load 'speedbar
-    (evil-collection-speedbar-setup)))
+  (evil-collection-init))
 
 (provide 'crafted-evil-config)
 ;;; crafted-evil-config.el ends here

--- a/modules/crafted-evil-config.el
+++ b/modules/crafted-evil-config.el
@@ -81,7 +81,13 @@ Rebinds the arrow keys to display a message instead."
                 term-mode))
   (add-to-list 'evil-emacs-state-modes mode))
 
-(evil-collection-init)
+(when (locate-library "evil-collection")
+  ;; Initialize evil-collection
+  (evil-collection-init)
+
+  ;; If speedbar is loaded, run evil-collection setup
+  (with-eval-after-load 'speedbar
+    (evil-collection-speedbar-setup)))
 
 (provide 'crafted-evil-config)
 ;;; crafted-evil-config.el ends here

--- a/modules/crafted-speedbar-config.el
+++ b/modules/crafted-speedbar-config.el
@@ -16,103 +16,99 @@
 ;; Rmail and projectile
 
 ;;; Code:
-
-;; require the module
 (require 'speedbar)
 
-;;; simple function for use in keybindings
-(defun speedbar-switch-to-quick-buffers ()
-  "Switch to quick-buffers expansion list."
+;;; Look & Feel
+;; Auto-update when the attached frame changes directory
+(customize-set-variable 'speedbar-update-flag t)
+
+;; Disable icon images, instead use text
+(customize-set-variable 'speedbar-use-images nil)
+
+;; Customize Speedbar Frame
+(customize-set-variable 'speedbar-frame-parameters
+                        '((name . "speedbar")
+                          (title . "speedbar")
+                          (minibuffer . nil)
+                          (border-width . 2)
+                          (menu-bar-lines . 0)
+                          (tool-bar-lines . 0)
+                          (unsplittable . t)
+                          (left-fringe . 10)))
+
+;;; Keybindings
+(defun crafted-speedbar-switch-to-quick-buffers ()
+  "Temporarily switch to quick-buffers expansion list.
+Useful for quickly switching to an open buffer."
   (interactive)
   (speedbar-change-initial-expansion-list "quick buffers"))
 
+;; map switch-to-quick-buffers in speedbar-mode
+(keymap-set speedbar-mode-map "b" 'crafted-speedbar-switch-to-quick-buffers)
 
-;;; Keybindings:
-;;;; evil-mode adjustments
-(with-eval-after-load 'speedbar
-  (with-eval-after-load 'evil
-    ;;edit/open file under point
-    (keymap-set speedbar-mode-map "<return>" 'speedbar-edit-line)
-    ;;toggle thing at point
-    (keymap-set speedbar-mode-map "<tab>" 'speedbar-toggle-line-expansion)
-    ;;evaluate as elisp if file at point is elisp, I dont use this too much but might be useful
-    (keymap-set speedbar-mode-map "C-<return>" 'speedbar-item-load)
-    ;;temporarly change mode in speedbar to "buffer-switching mode".
-    ;;useful for quickly switching to an open buffer
-    (keymap-set speedbar-mode-map "b" 'speedbar-switch-to-quick-buffers)))
+;;;; Adjustments for evil-mode
+(with-eval-after-load 'evil
+  ;; edit/open file under point (like non-evil or evil-collection)
+  (keymap-set speedbar-mode-map "<return>" 'speedbar-edit-line)
+  ;; toggle thing at point (like evil-collection)
+  (keymap-set speedbar-mode-map "<tab>" 'speedbar-toggle-line-expansion)
+  ;; Evaluate as elisp if file at point is elisp (like evil-collection)
+  (keymap-set speedbar-mode-map "L" 'speedbar-item-load))
 
 (with-eval-after-load 'evil-collection
   (evil-collection-speedbar-setup))
 
-;;; Set some sane defaults, can be easily extended by user.
-(setq-default speedbar-frame-parameters
-              '((name . "speedbar")
-                (title . "speedbar")
-                (minibuffer . nil)
-                (border-width . 2)
-                (menu-bar-lines . 0)
-                (tool-bar-lines . 0)
-                (unsplittable . t)
-                (left-fringe . 10)))
-
-;;; List of supported file-extensions
+;;; File Extensions
 (speedbar-add-supported-extension
  (list
-;;;; lua and fennel(lisp that transpiles to lua)
-  ".lua"
-  ".fnl"
-  ".fennel"
-;;;; shellscript
-  ".sh"
-  ".bash";;is this ever used?
-;;;; web languages
-;;;;; Hyper-Text-markup-language(html) and php
-  ".php"
-  ".html"
-  ".htm"
-;;;;; ecma(java/type)-script
-  ".js"
-  ".json"
-  ".ts"
-;;;;; stylasheets
-  ".css"
-  ".less"
-  ".scss"
-  ".sass"
-;;;; c/c++ and makefiles
-  ".c"
-  ".cpp"
-  ".h"
-  "makefile"
-  "MAKEFILE"
-  "Makefile"
-;;;; runs on JVM, java,kotlin etc
-  ".java"
-  ".kt";;this is for kotlin
-  ".mvn"
-  ".gradle" ".properties";; this is for gradle-projects
-  ".clj";;lisp on the JVM
-;;;; lisps
+;;;; General Lisp Languages
   ".cl"
   ".el"
   ".scm"
   ".lisp"
-;;;; configuration
+;;;; Lua/Fennel (Lisp that transpiles to lua)
+  ".lua"
+  ".fnl"
+  ".fennel"
+;;;; JVM languages (Java, Kotlin, Clojure)
+  ".java"
+  ".kt"
+  ".mvn"
+  ".gradle"
+  ".properties"
+  ".clj"
+;;;; C/C++
+  ".c"
+  ".cpp"
+  ".h"
+;;;; shellscript
+  ".sh"
+  ".bash"
+;;;; Web Languages and Markup/Styling
+  ".php"
+  ".js"
+  ".ts"
+  ".html"
+  ".htm"
+  ".css"
+  ".less"
+  ".scss"
+  ".sass"
+;;;; Makefile
+  "makefile"
+  "MAKEFILE"
+  "Makefile"
+;;;; Data formats
+  ".json"
   ".yaml"
   ".toml"
-;;;; notes,markup and orgmode
+;;;; Notes and Markup
   ".md"
   ".markdown"
   ".org"
   ".txt"
-  "README"
-  ))
+  "README"))
 
-;;; Make speedbar update automaticaly, and dont use ugly icons(images)
-;; this can be set back to use icons by simply doing
-;;`(setq-default speedbar-use-images t)` in your own config
-(setq-default speedbar-update-flag t)
-(setq-default speedbar-use-images nil)
-
+;;; _
 (provide 'crafted-speedbar-config)
 ;;; crafted-speedbar-config.el ends here

--- a/modules/crafted-speedbar-config.el
+++ b/modules/crafted-speedbar-config.el
@@ -46,18 +46,6 @@ Useful for quickly switching to an open buffer."
 ;; map switch-to-quick-buffers in speedbar-mode
 (keymap-set speedbar-mode-map "b" 'crafted-speedbar-switch-to-quick-buffers)
 
-;;;; Adjustments for evil-mode
-(with-eval-after-load 'evil
-  ;; edit/open file under point (like non-evil or evil-collection)
-  (keymap-set speedbar-mode-map "<return>" 'speedbar-edit-line)
-  ;; toggle thing at point (like evil-collection)
-  (keymap-set speedbar-mode-map "<tab>" 'speedbar-toggle-line-expansion)
-  ;; Evaluate as elisp if file at point is elisp (like evil-collection)
-  (keymap-set speedbar-mode-map "L" 'speedbar-item-load))
-
-(with-eval-after-load 'evil-collection
-  (evil-collection-speedbar-setup))
-
 ;;; File Extensions
 (speedbar-add-supported-extension
  (list


### PR DESCRIPTION
General overhaul of the speedbar module to be more in-line with other modules in terms of coding style and documentation (speedbar module docs still WIP).

- Reorganize top-level into "Look & Feel", "Keybindings" and "File Extensions"
- Rename `speedbar-switch-to-quick-buffers` to `crafted-speedbar-switch-to-quick-buffers` to comply with naming convention
- Always map the switch-to-quick-buffers function to "b" (not just in evil-mode)
- Use `customize-set-variable` for `defcustom` variables instead of `setq-default`
- move speedbar-specific `evil-collection` initialization to `crafted-evil-config`
- update code comments
- Update documentation to reflect changes and regenerate info buffer