### PR TITLE
[craftedv2beta] Use when instead of if, since else returns nil

### DIFF
--- a/modules/crafted-early-init-config.el
+++ b/modules/crafted-early-init-config.el
@@ -55,8 +55,8 @@ is skipped"
                                          (file-attributes archive-name))))
          (delta (make-decoded-time :day crafted-package-update-days)))
     (when crafted-package-perform-stale-archive-check
-        (time-less-p (encode-time (decoded-time-add last-update-time delta))
-                     (encode-time today)))))
+      (time-less-p (encode-time (decoded-time-add last-update-time delta))
+                   (encode-time today)))))
 
 (defun crafted-package-archives-stale-p ()
   "Return t if any package archives' cache is out of date.

--- a/modules/crafted-early-init-config.el
+++ b/modules/crafted-early-init-config.el
@@ -54,10 +54,9 @@ is skipped"
          (last-update-time (decode-time (file-attribute-modification-time
                                          (file-attributes archive-name))))
          (delta (make-decoded-time :day crafted-package-update-days)))
-    (if crafted-package-perform-stale-archive-check
+    (when crafted-package-perform-stale-archive-check
         (time-less-p (encode-time (decoded-time-add last-update-time delta))
-                     (encode-time today))
-      nil)))
+                     (encode-time today)))))
 
 (defun crafted-package-archives-stale-p ()
   "Return t if any package archives' cache is out of date.


### PR DESCRIPTION
Small thing I found while checking through the code.

Using `if` with an else-branch that returns `nil` is equivalent to using `when`.
Arguably more readable.

```emacs-lisp
;; old
(if <test>
    ...
  nil)

;; new
(when <test>
  ...)
```