### PR TITLE
[craftedv2beta] Prefer using format instead of concat

### DIFF
--- a/modules/crafted-ide-config.el
+++ b/modules/crafted-ide-config.el
@@ -36,8 +36,8 @@ manually with something like this:
                    (not (eq 'lisp-mode mode))     ; prefer sly/slime
                    (not (eq 'scheme-mode mode))   ; prefer geiser
                    )
-          (let ((hook-name (concat (symbol-name mode) "-hook")))
-            (message (concat "adding eglot to " hook-name))
+          (let ((hook-name (format "%s-hook" (symbol-name mode))))
+            (message "adding eglot to %s" hook-name)
             (add-hook (intern hook-name) #'eglot-ensure))))))))
 
 ;; add eglot to existing programming modes when eglot is loaded.
@@ -61,7 +61,7 @@ tree-sitter for LANG-SYMBOL.
 Example: `(crafted-tree-sitter-load 'python)'"
       (tree-sitter-require lang-symbol)
       (let ((mode-hook-name
-             (intern (concat (symbol-name lang-symbol) "-mode-hook"))))
+             (intern (format "%s-mode-hook" (symbol-name lang-symbol)))))
         (add-hook mode-hook-name #'tree-sitter-mode)))))
 
 ;; Emacs versions after 29

--- a/modules/crafted-init-config.el
+++ b/modules/crafted-init-config.el
@@ -79,14 +79,14 @@ explicitly."))
 
 (let ((modules (expand-file-name "./modules/" crafted-emacs-home)))
   (when (file-directory-p modules)
-    (message (concat "adding modules to load-path: " modules))
+    (message "adding modules to load-path: %s" modules)
     (add-to-list 'load-path modules)))
 
 ;; If a `custom-modules' directory exists in the
 ;; `user-emacs-directory', include it on the load-path.
 (let ((custom-modules (expand-file-name "custom-modules" user-emacs-directory)))
   (when (file-directory-p custom-modules)
-    (message "adding custom-modules to load-path")
+    (message "adding custom-modules to load-path: %s" custom-modules)
     (add-to-list 'load-path custom-modules)))
 
 ;; When writing crafted-modules, insert header from skeleton


### PR DESCRIPTION
We use format in most other contexts of similar nature. Especially with message, using the built-in formatting makes sense.

```emacs-lisp
;; old
(let ((mode "org"))
  (call-which-requires-mode-symbol (concat mode "-mode")))

;; new
(let ((mode "org"))
  (call-which-requires-mode-symbol (format "%s-mode" mode)))

;; old
(let ((mode "org"))
  (message (concat "I like " org "-mode")))

;; new
(let ((mode "org"))
  (message "I like %s-mode" mode))
```

I also added the formatting to print the path to custom-modules (like normal modules).
