### PR TITLE
[craftedv2beta] Use `#'` instead of `'` for passing functions

### DIFF
--- a/modules/crafted-evil-config.el
+++ b/modules/crafted-evil-config.el
@@ -65,14 +65,14 @@ Rebinds the arrow keys to display a message instead."
     (message "Use HJKL keys instead!"))
 
   ;; Disable arrow keys in normal and visual modes
-  (keymap-set evil-normal-state-map "<left>"  'crafted-evil-discourage-arrow-keys)
-  (keymap-set evil-normal-state-map "<right>" 'crafted-evil-discourage-arrow-keys)
-  (keymap-set evil-normal-state-map "<down>"  'crafted-evil-discourage-arrow-keys)
-  (keymap-set evil-normal-state-map "<up>"    'crafted-evil-discourage-arrow-keys)
-  (evil-global-set-key 'motion      (kbd "<left>")  'crafted-evil-discourage-arrow-keys)
-  (evil-global-set-key 'motion      (kbd "<right>") 'crafted-evil-discourage-arrow-keys)
-  (evil-global-set-key 'motion      (kbd "<down>")  'crafted-evil-discourage-arrow-keys)
-  (evil-global-set-key 'motion      (kbd "<up>")    'crafted-evil-discourage-arrow-keys))
+  (keymap-set evil-normal-state-map "<left>"  #'crafted-evil-discourage-arrow-keys)
+  (keymap-set evil-normal-state-map "<right>" #'crafted-evil-discourage-arrow-keys)
+  (keymap-set evil-normal-state-map "<down>"  #'crafted-evil-discourage-arrow-keys)
+  (keymap-set evil-normal-state-map "<up>"    #'crafted-evil-discourage-arrow-keys)
+  (evil-global-set-key 'motion      (kbd "<left>")  #'crafted-evil-discourage-arrow-keys)
+  (evil-global-set-key 'motion      (kbd "<right>") #'crafted-evil-discourage-arrow-keys)
+  (evil-global-set-key 'motion      (kbd "<down>")  #'crafted-evil-discourage-arrow-keys)
+  (evil-global-set-key 'motion      (kbd "<up>")    #'crafted-evil-discourage-arrow-keys))
 
 ;; Make sure some modes start in Emacs state
 ;; TODO: Split this out to other configuration modules?
@@ -88,9 +88,9 @@ Rebinds the arrow keys to display a message instead."
   ;; otherwise set up some defaults
   (with-eval-after-load 'crafted-completion-config
     (when (featurep 'vertico) ; only if `vertico' is actually loaded.
-      (keymap-set vertico-map "C-j" 'vertico-next)
-      (keymap-set vertico-map "C-k" 'vertico-previous)
-      (keymap-set vertico-map "M-h" 'vertico-directory-up))))
+      (keymap-set vertico-map "C-j" #'vertico-next)
+      (keymap-set vertico-map "C-k" #'vertico-previous)
+      (keymap-set vertico-map "M-h" #'vertico-directory-up))))
 
 (provide 'crafted-evil-config)
 ;;; crafted-evil-config.el ends here

--- a/modules/crafted-osx-config.el
+++ b/modules/crafted-osx-config.el
@@ -27,11 +27,11 @@
 
 ;; Keybinds
 
-(keymap-global-set "s-W" 'delete-frame) ; ⌘-W = Close window
-(keymap-global-set "s-}" 'tab-bar-switch-to-next-tab) ; ⌘-} = Next tab
-(keymap-global-set "s-{" 'tab-bar-switch-to-prev-tab) ; ⌘-{ = Previous tab
-(keymap-global-set "s-t" 'tab-bar-new-tab) ;⌘-t = New tab
-(keymap-global-set "s-w" 'tab-bar-close-tab) ; ⌘-w = Close tab
+(keymap-global-set "s-W" #'delete-frame) ; ⌘-W = Close window
+(keymap-global-set "s-}" #'tab-bar-switch-to-next-tab) ; ⌘-} = Next tab
+(keymap-global-set "s-{" #'tab-bar-switch-to-prev-tab) ; ⌘-{ = Previous tab
+(keymap-global-set "s-t" #'tab-bar-new-tab) ;⌘-t = New tab
+(keymap-global-set "s-w" #'tab-bar-close-tab) ; ⌘-w = Close tab
 
 (unless (version< emacs-version "28")
   (keymap-global-set "s-Z" 'undo-redo)) ; ⌘-Z = Redo

--- a/modules/crafted-speedbar-config.el
+++ b/modules/crafted-speedbar-config.el
@@ -44,7 +44,7 @@ Useful for quickly switching to an open buffer."
   (speedbar-change-initial-expansion-list "quick buffers"))
 
 ;; map switch-to-quick-buffers in speedbar-mode
-(keymap-set speedbar-mode-map "b" 'crafted-speedbar-switch-to-quick-buffers)
+(keymap-set speedbar-mode-map "b" #'crafted-speedbar-switch-to-quick-buffers)
 
 ;;; File Extensions
 (speedbar-add-supported-extension

--- a/modules/crafted-writing-config.el
+++ b/modules/crafted-writing-config.el
@@ -121,7 +121,7 @@ Example usage:
   (add-hook 'LaTeX-mode-hook #'LaTeX-math-mode)
 
   ;; add support for references
-  (add-hook 'LaTeX-mode-hook 'turn-on-reftex)
+  (add-hook 'LaTeX-mode-hook #'turn-on-reftex)
   (customize-set-variable 'reftex-plug-into-AUCTeX t)
 
   ;; to have the buffer refresh after compilation


### PR DESCRIPTION
We had some instances left over that used `'function` instead of `#'function`.
Fixing those.