### PR TITLE
[craftedv2beta] Fix obsolete keycast variables in `crafted-screencast` module

### DIFF
--- a/modules/crafted-screencast-config.el
+++ b/modules/crafted-screencast-config.el
@@ -12,8 +12,8 @@
 ;;; Code:
 
 (when (locate-library "keycast")
-  (customize-set-variable 'keycast-remove-tail-elements nil)
-  (customize-set-variable 'keycast-insert-after 'mode-line-misc-info)
+  (customize-set-variable 'keycast-mode-line-remove-tail-elements nil)
+  (customize-set-variable 'keycast-mode-line-insert-after 'mode-line-misc-info)
   (keycast-mode-line-mode))
 
 (provide 'crafted-screencast-config)


### PR DESCRIPTION
Last one for now ... I think :smile: 

`crafted-screencast-config` module set obsolete variables. 
Replaced them with the keycast 2.0 versions.