### PR TITLE
[craftedv2beta] Consistent org markup in docs

### DIFF
--- a/docs/CONTRIBUTING.org
+++ b/docs/CONTRIBUTING.org
@@ -16,33 +16,33 @@ Emacs configuration settings.
 ** Interactively from Emacs
 
 Requirements:
-- =emacs= in your =$PATH=
+- ~emacs~ in your ~$PATH~
 
 Evaluating this block will load the =crafted-docs.el= file into your Emacs:
 
 #+begin_src emacs-lisp
-(load (expand-file-name "crafted-docs.el"))
+  (load (expand-file-name "crafted-docs.el"))
 #+end_src
 
 Afterwards, the info file can be exported by running
 =M-x crafted-docs-export RET=.
 
 If you're using Crafted Emacs and develop inside the repository you cloned,
-you can set =crafted-docs-export-use-crafted-emacs-home= to =t= to utilize the
-=crafted-emacs-home= path to auto-find the documentation when running
+you can set ~crafted-docs-export-use-crafted-emacs-home~ to =t= to utilize the
+~crafted-emacs-home~ path to auto-find the documentation when running
 =M-x crafted-docs-export RET=.
 
 ** Using ~make~
 
 Requirements:
-- =emacs= in your =$PATH=
-- =make= in your =$PATH=
+- ~emacs~ in your ~$PATH~
+- ~make~ in your ~$PATH~
 
-If you're familiar with =make= and already have a workflow using for example
-the =compile= command in Emacs, you can use it in the =docs/= directory:
+If you're familiar with ~make~ and already have a workflow using for example
+the ~compile~ command in Emacs, you can use it in the =docs/= directory:
 
 #+begin_src shell
-make docs
+  make docs
 #+end_src
 
 Running =make docs= will automatically build the =crafted-emacs.info= file
@@ -63,11 +63,27 @@ unless the info file is already up-to-date.
 
 * Guidelines
 
+  + Provide examples.
   + Make sure your grammar is correct.
   + Spellcheck your work.
+  + Use consistent formatting in the org docs:
+    - use === for ::
+      + file paths, e.g. =init.el=
+      + buffer names, e.g. =*Messages*=
+      + values (except numbers, which stay plain), e.g. =nil=
+      + keystrokes or keybindings, e.g. =C-n=
+      + text (to be) entered into the minibuffer (unless it is a complete
+        command name), e.g. =buf=
+      + info nodes, e.g. =(emacs)Just Spaces=
+    - use =~= for ::
+      + module names, e.g. ~crafted-defaults-config~
+      + variable names, incl. external ones, e.g. ~load-prefer-newer~, ~$PATH~
+      + function names, e.g. ~car~
+      + command names, incl. external ones, e.g. ~find-file~, ~make~
+      + package names, incl. ones that are shaped like a file name, e.g. ~denote~,
+        ~package.el~
   + Preview the info document in Emacs to make sure the formatting
     works.
   + Use =@@texinfo:@code{}@@= or =@@texinfo:@samp{}@@= tags in
-    headers, captions, or other places where org formatting does not
-    directly translate correctly.
-  + Provide examples.
+    places where org formatting does not directly translate correctly.
+

--- a/docs/crafted-completion.org
+++ b/docs/crafted-completion.org
@@ -37,7 +37,7 @@ through them step by step.
 For each step, imagine you want to switch buffers but you neither remember the
 binding nor the command to do that. Neither do you remember that the command
 starts with "switch". But you're sure it was something with buffers, so you
-hit "M-x" and type =buf=.
+hit =M-x= and type =buf=.
 
 A fresh Emacs install would actually be pretty helpful for that already. After
 =buf= you could hit <SPC> or <TAB> to complete to =buffer-= and after trying
@@ -100,45 +100,45 @@ info on what they're doing.
 
 Consult provides a set of practical commands. A lot of them are
 [[https://github.com/minad/consult#available-commands][replacements for built-in everyday functions]]. (For example, try replacing
-=switch-to-buffer= with =consult-buffer=. Or replace =yank-pop= with
-=consult-yank-pop=). However, Crafted Emacs leaves most of that
-untouched. It's up to you as the user.  The module =crafted-completion= sets
+~switch-to-buffer~ with ~consult-buffer~. Or replace ~yank-pop~ with
+~consult-yank-pop~). However, Crafted Emacs leaves most of that
+untouched. It's up to you as the user.  The module ~crafted-completion~ sets
 three consult functions for you that fit into the completion behaviour
 described above.
 
-- Search-/filtering candidates and bind "C-s" to =consult-line=
+- Search-/filtering candidates and bind =C-s= to ~consult-line~
   Whenever you're presented with candidates for completions, consult
   provides a filtering search function which updates not only the list
   of candidates in the minibuffer, but also the active buffer in a
   sort of live preview (if applicable). Crafted Emacs also replaces
-  =isearch= with =consult-line=, so that searching through your buffer
-  gives you the same behaviour. Essentially, =isearch-backward= becomes
+  ~isearch~ with ~consult-line~, so that searching through your buffer
+  gives you the same behaviour. Essentially, ~isearch-backward~ becomes
   obsolete, because consult shows you the forward matches first and
   next the backward matches and you can cycle through them.
 
   [[./img/06-consult-line.png]]
 
-- Bind "C-r" in the minibuffer to =consult-history=
+- Bind =C-r= in the minibuffer to ~consult-history~
 
   Whenever you're presented with candidates for completions in a minibuffer,
-  =consult= automatically sorts your most recently used candidates to the
-  top. Also it is searchable like with =consult-line=. Inside a minibuffer,
+  ~consult~ automatically sorts your most recently used candidates to the
+  top. Also it is searchable like with ~consult-line~. Inside a minibuffer,
   you can also hit "C-r" to show *only* the candidates you have used before.
 
   [[./img/07-consult-history.png]]
 
-- Use =consult-completion-in-region= as completion function
+- Use ~consult-completion-in-region~ as completion function
 
   Completion not only comes into effect in the minibuffer, but also
   (depending on other settings – like major mode) within your main
   buffer. E.g. completing function or variable names etc.
 
-  *Without* =consult=, triggering a completion gives you a static list of
+  *Without* ~consult~, triggering a completion gives you a static list of
   candidates if there is more than one.
 
   [[./img/08-completion-without-consult.png]]
 
-  *With* =consult=, the list of candidates is dynamic as you type and updates
+  *With* ~consult~, the list of candidates is dynamic as you type and updates
   the current selection as a preview in the buffer.
 
   [[./img/09-completion-with-consult.png]]
@@ -150,29 +150,29 @@ here. We highly recommend to read through the [[https://github.com/oantolin/emba
 
 As it's set up in this module, Embark offers two main features:
 
-- =embark-act=
+- ~embark-act~
 
-  The =embark-act= function (bound to "C-.") offers you a lot of possible
+  The ~embark-act~ function (bound to =C-.=) offers you a lot of possible
   actions that can be applied to the element of the buffer (or minibuffer)
   in which your cursor is positioned. You can think of this as a context
   menu, similar to what you achieve in many user interfaces by
   right-clicking on something.
 
-  But =embark-act= can be used for much more, have a look at the video
+  But ~embark-act~ can be used for much more, have a look at the video
   [[https://youtu.be/qk2Is_sC8Lk][The Many Uses of Embark]] in the System Crafters Channel.
 
-- =embark-bindings= & =embark-prefix-help-command=
+- ~embark-bindings~ & ~embark-prefix-help-command~
 
-  Crafted Emacs replaces =describe-bindings= and =prefix-help-command= with
+  Crafted Emacs replaces ~describe-bindings~ and ~prefix-help-command~ with
   their Embark-alternatives to provide a functionality similar to packages
-  like =which-key=: It shows you available options and commands, but with all
+  like ~which-key~: It shows you available options and commands, but with all
   the goodies provided by the other packages above.
 
   For one last time, imagine you want so switch buffers and have forgotten
   how. But this time, you also remember that there was a binding for it,
-  probably starting with "C-x".
+  probably starting with =C-x=.
 
-  You can hit "C-x C-h" to see a list of possible bindings after the "C-x"
+  You can hit =C-x C-h= to see a list of possible bindings after the =C-x=
   prefix. But you don't need to cycle through them, you can fuzzy-filter
   them. Type "buf" to see only the bindings that relate to buffers.
 
@@ -183,7 +183,7 @@ As it's set up in this module, Embark offers two main features:
 Corfu provides a completion overlay while you are typing in a regular
 buffer. How these overlays are triggered depends on the major mode of
 the buffer. This module sets up corfu so that it almost always triggers
-automatically. Otherwise, try hitting <TAB> or by ~C-M-i~, which are the
+automatically. Otherwise, try hitting <TAB> or by =C-M-i=, which are the
 regular completion at point commands.
 In programming modes, it's also set up to show documentation if possible,
 so the effect is similar to how other IDEs offer popup completions.

--- a/docs/crafted-defaults.org
+++ b/docs/crafted-defaults.org
@@ -17,7 +17,7 @@ points.
 
 ** Description
 
-The =crafted-defaults= module provides a variety of sensible settings that are
+The ~crafted-defaults~ module provides a variety of sensible settings that are
 commonly held to be universally useful for Emacs users.
 
 These defaults have been grouped into loose categories. However, most of them
@@ -30,7 +30,7 @@ the default.
 
 ** Buffers
 
-- =global-auto-revert-non-file-buffers= : =t=
+- ~global-auto-revert-non-file-buffers~ : =t=
 
   Automatically update buffers not backed by files (e.g. a directory listing in
   dired) if they are changed outside Emacs (e.g. by version control or a file
@@ -43,7 +43,7 @@ the default.
     (customize-set-variable 'global-auto-revert-non-file-buffers nil)
   #+end_src
 
-- =global-auto-revert-mode=
+- ~global-auto-revert-mode~
 
   Activate a global minor mode to revert any buffer when it changes either on
   disk or via another process (see above). Affects file buffers, too.
@@ -54,7 +54,7 @@ the default.
     (global-auto-revert-mode -1)
   #+end_src
 
-- =dired-dwim-target= : =t=
+- ~dired-dwim-target~ : =t=
 
   When dired shows two directories in separate dired buffers and you use copy
   or move commands in one of them, dired will assume the other directory as
@@ -67,7 +67,7 @@ the default.
     (customize-set-variable 'dired-dwim-target nil)
   #+end_src
 
-- =dired-auto-revert-buffer= : =t=
+- ~dired-auto-revert-buffer~ : =t=
 
   When revisiting a directory, automatically update dired buffers.
 
@@ -78,7 +78,7 @@ the default.
     (customize-set-variable 'dired-auto-revert-buffer nil)
   #+end_src
 
-- =eshell-scroll-to-bottom-on-input= : =this=
+- ~eshell-scroll-to-bottom-on-input~ : =this=
 
   In eshell buffers, scroll to the bottom on input, but only in the selected
   window.
@@ -91,7 +91,7 @@ the default.
     (customize-set-variable 'eshell-scroll-to-bottom-on-input nil)
   #+end_src
 
-- =switch-to-buffer-in-dedicated-window= : =pop=
+- ~switch-to-buffer-in-dedicated-window~ : =pop=
 
   Pop up dedicated buffers in a different window.
 
@@ -102,10 +102,10 @@ the default.
     (customize-set-variable 'switch-to-buffer-in-dedicated-window nil)
   #+end_src
 
-  See the documentation for =switch-to-buffer-in-dedicated-window= for more
+  See the documentation for ~switch-to-buffer-in-dedicated-window~ for more
   options.
 
-- =switch-to-buffer-obey-display-actions= : =t=
+- ~switch-to-buffer-obey-display-actions~ : =t=
 
   Treat manual buffer switching (C-x b for example) the same as programmatic
   buffer switching.
@@ -128,7 +128,7 @@ the default.
     (keymap-global-set "<remap> <list-buffers>" #'list-buffers)
   #+end_src
 
-- =ibuffer-movement-cycle= : =nil=
+- ~ibuffer-movement-cycle~ : =nil=
 
   When using ibuffer, turn off cycling forward and backward.
 
@@ -139,7 +139,7 @@ the default.
     (customize-set-variable 'ibuffer-movement-cycle t)
   #+end_src
 
-- =ibuffer-old-time= : 24
+- ~ibuffer-old-time~ : 24
 
   In ibuffer, consider buffers "old" after 24 hours.
 
@@ -152,14 +152,14 @@ the default.
 
 ** Completion
 
-- =fido-vertical-mode=, =icomplete-vertical-mode= or =icomplete-mode=
+- ~fido-vertical-mode~, ~icomplete-vertical-mode~ or ~icomplete-mode~
 
   Turn on the best completion-mode available:
 
-  - In Emacs 28 or later, turn on =fido-vertical-mode=.
-  - In earlier versions, if the additional package =icomplete-vertical= is
-    installed, turn on =icomplete-vertical-mode=.
-  - Otherwise, turn on =icomplete-mode=.
+  - In Emacs 28 or later, turn on ~fido-vertical-mode~.
+  - In earlier versions, if the additional package ~icomplete-vertical~ is
+    installed, turn on ~icomplete-vertical-mode~.
+  - Otherwise, turn on ~icomplete-mode~.
 
   You can change this by turning off the respective mode in your config, e.g.
   like this:
@@ -169,32 +169,32 @@ the default.
   #+end_src
 
   Note:
-  - To install =icomplete-vertical=, add the following code to the packages phase
+  - To install ~icomplete-vertical~, add the following code to the packages phase
     of your config:
 
   #+begin_src emacs-lisp
     (add-to-list 'package-selected-packages 'icomplete-vertical)
   #+end_src
    
-  - If you also use =crafted-completion-config= and have the package =vertico=
-    installed, all of these modes will be turned off in favour of =vertico=.
+  - If you also use ~crafted-completion-config~ and have the package ~vertico~
+    installed, all of these modes will be turned off in favour of ~vertico~.
 
 
 The following settings will apply, no matter which completion mode you use.
 
-- =tab-always-indent= : =complete=
+- ~tab-always-indent~ : =complete=
 
   When hitting the TAB key, Emacs first tries to indent the current line.
   If it is already indented, it tries to complete the thing at point.
 
-  To change this, see the documentation of =tab-always-indent= and change it in
+  To change this, see the documentation of ~tab-always-indent~ and change it in
   your config (or the Customizations UI) to reflect the desired behaviour, e.g.:
 
   #+begin_src emacs-lisp
     (customize-set-variable 'tab-always-indent nil)
   #+end_src
 
-- =completion-cycle-threshold= : =3=
+- ~completion-cycle-threshold~ : 3
 
   When selection completion candidates, setting this variable uses cycling, i.e.
   completing each of the candidates in turn. This set it up to use cycling as
@@ -207,7 +207,7 @@ The following settings will apply, no matter which completion mode you use.
     (customize-set-variable 'completion-cycle-threshold 3)
   #+end_src
 
-- =completion-category-overrides= : =file= : =partial-completion=
+- ~completion-category-overrides~ : =file= : =partial-completion=
 
   When completing file names, this settings allows for partial completion. When
   you type part of the filename Emacs will complete the rest if there's no
@@ -221,10 +221,10 @@ The following settings will apply, no matter which completion mode you use.
 
   Or see the documentation of the variable for alternatives. You can also use
   it for other category specific completion settings. For example, you can use
-  it to specify a different =completion-cycle-threshold= (see above) for files
+  it to specify a different ~completion-cycle-threshold~ (see above) for files
   and buffers respectively.
 
-- =completions-detailed= : =t=
+- ~completions-detailed~ : =t=
 
   Display completions with details (for example in C-h o).
 
@@ -234,7 +234,7 @@ The following settings will apply, no matter which completion mode you use.
     (customize-set 'completions-detailed nil)
   #+end_src
 
-- =xref-show-definitions-function= : =xref-show-definitions-completing-read=
+- ~xref-show-definitions-function~ : ~xref-show-definitions-completing-read~
 
   When using a definition search, and there is more than one definition, let
   the user choose between them by typing in the minibuffer with completion.
@@ -250,7 +250,7 @@ The following settings will apply, no matter which completion mode you use.
 
 ** Editing
 
-- =delete-selection-mode=
+- ~delete-selection-mode~
 
   Typed text replaces the selection if the selection is active, pressing delete
   or backspace deletes the selection.
@@ -261,7 +261,7 @@ The following settings will apply, no matter which completion mode you use.
     (delete-selection-mode -1)
   #+end_src
 
-- =indent-tabs-mode= : =nil=
+- ~indent-tabs-mode~ : =nil=
 
   Only indent using spaces.
 
@@ -272,11 +272,11 @@ The following settings will apply, no matter which completion mode you use.
     (customize-set-variable 'indent-tabs-mode t)
   #+end_src
 
-- =kill-do-not-save-duplicates= : =t=
+- ~kill-do-not-save-duplicates~ : =t=
 
-  The =kill-ring= is where Emacs stores the strings to paste later. This variable
+  The ~kill-ring~ is where Emacs stores the strings to paste later. This variable
   prohibits Emacs from storing duplicates of strings which are already on the
-  =kill-ring=.
+  ~kill-ring~.
 
   Change this setting either by finding it in the Customization UI or by adding
   this code to your config:
@@ -285,7 +285,7 @@ The following settings will apply, no matter which completion mode you use.
     (customize-set-variable 'kill-do-not-save-duplicates nil)
   #+end_src
 
-- =bidi-paragraph-direction= : =left-to-right=
+- ~bidi-paragraph-direction~ : =left-to-right=
 
   Force directionality of text paragraphs in the buffer. Crafted Emacs sets
   the default value as =left-to-right=, which means for buffers which don't have
@@ -298,7 +298,7 @@ The following settings will apply, no matter which completion mode you use.
     (customize-set-variable 'bidi-paragraph-direction 'right-to-left)
   #+end_src
 
-- =bidi-inhibit-bpa= : =t=
+- ~bidi-inhibit-bpa~ : =t=
 
   This setting will inhibit the Bidirectional Parentheses Algorithm, which
   makes redisplay faster.
@@ -309,7 +309,7 @@ The following settings will apply, no matter which completion mode you use.
     (setq bidi-inhibit-bpa nil)
   #+end_src
 
-- =global-so-long-mode=
+- ~global-so-long-mode~
 
   Improve performance for files with excessively long lines.
 
@@ -321,8 +321,8 @@ The following settings will apply, no matter which completion mode you use.
 
 - Look up dictionary definitions
 
-  Using ~M-#~ will lookup the word at point in a dictionary. See the documentation
-  of =dictionary-lookup-definition= or the README of the built-in =dictionary.el=
+  Using =M-#= will lookup the word at point in a dictionary. See the documentation
+  of ~dictionary-lookup-definition~ or the README of the built-in =dictionary.el=
   for details (https://github.com/myrkr/dictionary-el). It is set up to show
   dictionary definitions in a side window on the left (see the settings for
   Special Windows below).
@@ -337,7 +337,7 @@ The following settings will apply, no matter which completion mode you use.
 
 - Flyspell Mode
 
-  If =ispell= is available, this module automatically turns on =flyspell-mode=
+  If ~ispell~ is available, this module automatically turns on ~flyspell-mode~
   for text-mode and for the comments in prog-mode.
 
   You can change this by adding this code to your config:
@@ -349,27 +349,27 @@ The following settings will apply, no matter which completion mode you use.
 
 ** Navigation
 
-If you have the packages =hydra= and =dumb-jump= installed, this module adds a hydra
-definition for dumb-jump and binds it to ~C-M-y~.
+If you have the packages ~hydra~ and ~dumb-jump~ installed, this module adds a hydra
+definition for dumb-jump and binds it to =C-M-y=.
 
-You can change that binding by adding this code to your config, replace ~C-M-y~
+You can change that binding by adding this code to your config, replace =C-M-y=
 by the key stroke you prefer:
 
   #+begin_src emacs-lisp
     (keymap-set dumb-jump-mode-map "C-M-y" #'dumb-jump-hydra/body)
   #+end_src
 
-You can also use the =defhydra= command to overwrite the hydra. See the
+You can also use the ~defhydra~ command to overwrite the hydra. See the
 documentation of the hydra package for details.
 
 ** Persistence
 
-- =recentf-mode=
+- ~recentf-mode~
 
   This minor mode saves the files you visit as a recent file so you can load
-  that file again quickly. The command =recentf-open-files= will display a menu
+  that file again quickly. The command ~recentf-open-files~ will display a menu
   of files you opened recently so you can quickly open it again. This mode is
-  added to the =after-init-hook= which runs when Emacs is starting but after the
+  added to the ~after-init-hook~ which runs when Emacs is starting but after the
   initialization files have completed running.
 
   You can change the location of the recent file by adding this to your config:
@@ -384,7 +384,7 @@ documentation of the hydra package for details.
     (remove-hook 'after-init-hook 'recentf-mode)
   #+end_src
 
-- =savehist-mode=
+- ~savehist-mode~
 
   This minor mode saves minibuffer history in the =history= file. You can change
   the location of the file with the Customization UI or by adding the following
@@ -401,11 +401,11 @@ documentation of the hydra package for details.
     (savehist-mode -1)
   #+end_src
 
-- =bookmark-save-flag= : =1=
+- ~bookmark-save-flag~ : 1
 
   Save bookmarks to file every time you make or delete a bookmark.
 
-  To change this, see the documentation of =bookmark-save-flag= for valid values
+  To change this, see the documentation of ~bookmark-save-flag~ for valid values
   and then add code like this to your config (e.g. to never save bookmarks):
 
   #+begin_src emacs-lisp
@@ -414,19 +414,19 @@ documentation of the hydra package for details.
 
 ** Windows
 
-- =winner-mode=
+- ~winner-mode~
 
   Enable [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Window-Convenience.html][winner-mode]] and provides a set of keybindings that help you navigate
   through multiple windows.
 
-  =winner-mode= is a minor mode that, when activated, allows you to revert to a
+  ~winner-mode~ is a minor mode that, when activated, allows you to revert to a
   prior windows arrangement. It provides two functions to allow this:
-  =winner-undo= and =winner-redo=. These take you to earlier and later windows
+  ~winner-undo~ and ~winner-redo~. These take you to earlier and later windows
   arrangements respectively.
 
   To store the keybindings associated with this module, a new keymap is
-  created: =crafted-windows-key-map=, Additionally, this module defines a custom
-  variable, =crafted-windows-prefix-key=, which allows you to set the prefix key
+  created: ~crafted-windows-key-map~, Additionally, this module defines a custom
+  variable, ~crafted-windows-prefix-key~, which allows you to set the prefix key
   to the keymap. By default, this is set to =C-c w=, but you are free to change
   it.
 
@@ -462,9 +462,9 @@ documentation of the hydra package for details.
     (winner-mode -1)
   #+end_src
 
-- =auto-window-vscroll= : =nil=
+- ~auto-window-vscroll~ : =nil=
 
-  Turn off the automatic adjustment of =window-vscroll= to view tall lines.
+  Turn off the automatic adjustment of ~window-vscroll~ to view tall lines.
   Together with the following four settings, this makes scrolling less
   stuttered.
 
@@ -474,7 +474,7 @@ documentation of the hydra package for details.
     (setq auto-window-vscroll t)
   #+end_src
 
-- =fast-but-imprecise-scrolling= : =t=
+- ~fast-but-imprecise-scrolling~ : =t=
 
   Improves scrolling speed by not rendering fontification updates unless the
   text would actually be visible in the buffer. Applies when scrolling very
@@ -488,7 +488,7 @@ documentation of the hydra package for details.
     (customize-set-variable 'fast-but-imprecise-scrolling nil)
   #+end_src
 
-- =scroll-conservatively= : 101
+- ~scroll-conservatively~ : 101
 
   If the point moves off the screen, redisplay will scroll by up to 101 lines
   to bring it back on the screen again. If that is not enough, redisplay will
@@ -504,20 +504,20 @@ documentation of the hydra package for details.
   #+end_src
 
 
-- =scroll-margin= : 0
+- ~scroll-margin~ : 0
 
   Turn off automatic scrolling when the point comes near to the bottom or top
   of the window. Together with other settings in this section, this makes
   scrolling less stuttered.
 
-  To change this, set =scroll-margin= to a number of lines within which automatic
+  To change this, set ~scroll-margin~ to a number of lines within which automatic
   scrolling should be triggered, e.g.
 
   #+begin_src emacs-lisp
     (customize-set-variable 'scroll-margin 5)
   #+end_src
 
-- =scroll-preserve-screen-position= : =t=
+- ~scroll-preserve-screen-position~ : =t=
 
   When scrolling, move the point to keep its screen position unchanged.
   Together with other settings in this section, this makes scrolling less
@@ -529,7 +529,7 @@ documentation of the hydra package for details.
     (customize-set-variable 'scroll-preserve-screen-position nil)
   #+end_src
 
-- =Man-notify-method= : =aggressive=
+- ~Man-notify-method~ : =aggressive=
 
   Open man pages in their own window, and switch to that window to facilitate
   reading and closing the man page.
@@ -540,9 +540,9 @@ documentation of the hydra package for details.
     (customize-set-variable 'Man-notify-method 'friendly)
   #+end_src
 
-  See the documentation of =Man-notify-method= for other valid values.
+  See the documentation of ~Man-notify-method~ for other valid values.
 
-- =ediff-window-setup-function= : =ediff-setup-windows-plain=
+- ~ediff-window-setup-function~ : =ediff-setup-windows-plain=
 
   When using Ediff, keep the control panel in the same frame.
 
@@ -553,9 +553,9 @@ documentation of the hydra package for details.
                             'ediff-setup-windows-default)
   #+end_src
 
-  See the documentation of =ediff-window-setup-function= for details.
+  See the documentation of ~ediff-window-setup-function~ for details.
 
-- Special windows - =display-buffer-alist=
+- Special windows - ~display-buffer-alist~
 
   Define rules how Emacs opens some special windows.
 
@@ -567,11 +567,11 @@ documentation of the hydra package for details.
   - =*Help*=        :: If two windows are open, use not the current one, but the
                      other one. If only one window is open, open a new one.
 
-  To change this, see the documentation of =display-buffer-alist=.
+  To change this, see the documentation of ~display-buffer-alist~.
 
 ** Miscellaneous
 
-- =load-prefer-newer= : =t=
+- ~load-prefer-newer~ : =t=
 
   When both a compiled (.elc or .eln) and an uncompiled (.el) variant of a
   source file is present, load whichever is newest. This prevents puzzling
@@ -585,7 +585,7 @@ documentation of the hydra package for details.
     (customize-set-variable 'load-prefer-newer nil)
   #+end_src
 
-- =executable-make-buffer-file-executable-if-script-p=
+- ~executable-make-buffer-file-executable-if-script-p~
 
   When saving a file that starts with the shebang (=#!=), make that file
   executable.
@@ -597,19 +597,19 @@ documentation of the hydra package for details.
                  'executable-make-buffer-file-executable-if-script-p)
   #+end_src
 
-- =repeat-mode=
+- ~repeat-mode~
 
   If available (beginning with Emacs 28), turn on repeat mode to allow certain
   keys to repeat on the last keystroke.
 
-  For example, ~C-x [~ to page backward, after pressing this keystroke once,
-  pressing repeated ~[~ keys will continue paging backward.
+  For example, =C-x [= to page backward, after pressing this keystroke once,
+  pressing repeated =[= keys will continue paging backward.
 
-  =repeat-mode= is exited with the normal ~C-g~, by movement keys, typing, or
+  ~repeat-mode~ is exited with the normal =C-g=, by movement keys, typing, or
   pressing ESC three times.
 
-  Note that in the case of =undo= (by default bound to ~C-x u~), pressing ~u~
-  repeatedly will iterate further undos, but typing ~C-x u~ again will act as an
+  Note that in the case of ~undo~ (by default bound to =C-x u=), pressing =u=
+  repeatedly will iterate further undos, but typing =C-x u= again will act as an
   undo of the undo, i.e. a redo, which is handy, but possibly unexpected.
 
   To change this, add the following code to your config:

--- a/docs/crafted-emacs.info
+++ b/docs/crafted-emacs.info
@@ -1,7 +1,7 @@
 This is crafted-emacs.info, produced by makeinfo version 7.0.3 from
 crafted-emacs.texi.
 
-Copyright © 2022 System Crafters Community
+Copyright © 2023 System Crafters Community
 
      Permission is hereby granted, free of charge, to any person
      obtaining a copy of this software and associated documentation
@@ -337,10 +337,10 @@ File: crafted-emacs.info,  Node: Getting Started,  Next: Customization,  Prev: W
 4 Getting Started
 *****************
 
-Welcome to _Crafted Emacs_.
+Welcome to Crafted Emacs.
 
-   This section provides introductory material for setting up _Crafted
-Emacs_.  We’ll approach this from the perspective of the brand new Emacs
+   This section provides introductory material for setting up Crafted
+Emacs.  We’ll approach this from the perspective of the brand new Emacs
 user.
 
    If you are already familiar with Emacs, you’ll be able to skim this
@@ -388,8 +388,8 @@ something else.
 
    If you aren’t starting from scratch, then you probably have some
 configuration already working and you want to add or use some of the
-configuration found in _Crafted Emacs_.  You probably have to adapt and
-rewrite parts of your configuration to work with _Crafted Emacs_.
+configuration found in Crafted Emacs.  You probably have to adapt and
+rewrite parts of your configuration to work with Crafted Emacs.
 
    Wherever you decide to put your Emacs configuration will be known as
 ‘user-emacs-directory’ for the rest of this guide.
@@ -400,15 +400,15 @@ File: crafted-emacs.info,  Node: Cloning the repository,  Prev: Cleaning out you
 4.1.2 Cloning the repository
 ----------------------------
 
-To use _Crafted Emacs_, you will need to download the repository.  It is
+To use Crafted Emacs, you will need to download the repository.  It is
 up to you where you clone to.  If you are not sure where to clone to,
 you can use your home directory.
 
      # N.B. As this is still a beta release, use the craftedv2beta branch
      git clone https://github.com/SystemCrafters/crafted-emacs -b craftedv2beta
 
-   For the rest of this guide, the location where you cloned _Crafted
-Emacs_ to will be known as ‘crafted-emacs-home’.
+   For the rest of this guide, the location where you cloned Crafted
+Emacs to will be known as ‘crafted-emacs-home’.
 
 
 File: crafted-emacs.info,  Node: Bootstrapping Crafted Emacs,  Next: Crafted Emacs Modules,  Prev: Initial setup,  Up: Getting Started
@@ -417,7 +417,7 @@ File: crafted-emacs.info,  Node: Bootstrapping Crafted Emacs,  Next: Crafted Ema
 ===============================
 
 After cloning the crafted-emacs repository, we need to let Emacs know
-how to load _Crafted Emacs_.
+how to load Crafted Emacs.
 
 * Menu:
 
@@ -478,7 +478,7 @@ the ‘user-emacs-directory’:
      listed above.  This means, we prefer to get packages from GNU Elpa
      first, if not found, then try the next repository down the list,
      finally trying to get the package from MELPA as a last resort.
-     This is because _Crafted Emacs_ prefers released versions, if
+     This is because Crafted Emacs prefers released versions, if
      available, for all packages installed.
    • Check to make sure the repository cache archives are up-to-date,
      and update if needed.  This check is performed when Emacs is
@@ -488,8 +488,8 @@ the ‘user-emacs-directory’:
      the check at all, set the
      ‘crafted-package-perform-stale-archive-check’ variable to ‘nil’.
 
-   Once _Crafted Emacs_ is up and running, no stale checks are made.
-Thus, if you run _Crafted Emacs_ for several days without restarting
+   Once Crafted Emacs is up and running, no stale checks are made.
+Thus, if you run Crafted Emacs for several days without restarting
 Emacs, you’ll need to refresh the package repository archive caches
 manually.  This is done automatically when running
 ‘package-list-packages’.
@@ -549,8 +549,8 @@ File: crafted-emacs.info,  Node: Crafted Emacs Modules,  Next: Example Configura
 4.3 Crafted Emacs Modules
 =========================
 
-Now that you have bootstrapped _Crafted Emacs_, you can start
-configuring Emacs using Crafted Emacs Modules.
+Now that you have bootstrapped Crafted Emacs, you can start configuring
+Emacs using Crafted Emacs Modules.
 
 * Menu:
 
@@ -564,23 +564,23 @@ File: crafted-emacs.info,  Node: Installing packages,  Next: Using Crafted Emacs
 -------------------------
 
 The standard approach to finding and installing packages is to use the
-command ‘M-x list-packages RET’, which will bring up a user interface to
-search for packages, review the package details, install, update or
+command ‘M-x’ ‘list-packages RET’, which will bring up a user interface
+to search for packages, review the package details, install, update or
 remove package.  For more information: *note Packages: (emacs)Packages.
 or on the web: Packages
 (https://www.gnu.org/software/emacs/manual/html_node/emacs/Packages.html).
 
-   _Crafted Emacs_ uses the selection facilities for batch-installation
-of packages.  This means all packages are added to a list (namely
+   Crafted Emacs uses the selection facilities for batch-installation of
+packages.  This means all packages are added to a list (namely
 ‘package-selected-packages’) and installed at once.
 
      ;; Example: Adding "vertico" to the package-selected-packages list (init.el)
      (add-to-list 'package-selected-packages 'vertico)
 
-   Additionally, _Crafted Emacs_ provides a few modules which are
-bundled together packages for installation.  Each of these modules
-simply adds one or more package names to the ‘package-selected-packages’
-list, for example:
+   Additionally, Crafted Emacs provides a few modules which are bundled
+together packages for installation.  Each of these modules simply adds
+one or more package names to the ‘package-selected-packages’ list, for
+example:
 
      ;; snippet of crafted-completion-packages.el:
      ;; not all package names are shown here, the list is shortened for
@@ -604,7 +604,7 @@ File: crafted-emacs.info,  Node: Using Crafted Emacs Modules,  Prev: Installing 
 4.3.2 Using Crafted Emacs Modules
 ---------------------------------
 
-There are two types of modules provided by _Crafted Emacs_.
+There are two types of modules provided by Crafted Emacs.
 
   1. Package modules (bundle together multiple packages for
      installation)
@@ -615,7 +615,7 @@ There are two types of modules provided by _Crafted Emacs_.
   1. Package definitions: crafted-*-packages
 
      As explained earlier in the guide, you can add packages manually
-     using ‘add-to-list’.  Additionally, _Crafted Emacs_ provides a few
+     using ‘add-to-list’.  Additionally, Crafted Emacs provides a few
      modules which are bundled together packages for installation.  Each
      of these modules simply adds one or more package names to the
      ‘package-selected-packages’ list.  The bundles of packages are
@@ -635,9 +635,9 @@ There are two types of modules provided by _Crafted Emacs_.
           # In a shell/term from the crafted-emacs-home directory
           ls ./modules/*-packages.el
 
-  2. Configuration: crafted-*-config
+  2. Configuration: ‘crafted-*-config’
 
-     The configuration code provided by _Crafted Emacs_ is to be loaded
+     The configuration code provided by Crafted Emacs is to be loaded
      after installing all the packages.
 
           ;; install selected packages
@@ -761,9 +761,9 @@ need to run those two functions.
 selected packages during each startup, you can turn that behaviour off
 as described above.
 
-   Please note: These variables only affect whether _Crafted Emacs_ will
-or won’t automatically store anything set by customize-set-variable, but
-that doesn’t hinder other processes in Emacs to do so.
+   Please note: These variables only affect whether Crafted Emacs will
+or won’t automatically store anything set by ‘customize-set-variable’,
+but that doesn’t hinder other processes in Emacs to do so.
 
 
 File: crafted-emacs.info,  Node: Where to go from here,  Prev: To save or not to save customizations,  Up: Getting Started
@@ -771,7 +771,7 @@ File: crafted-emacs.info,  Node: Where to go from here,  Prev: To save or not to
 4.6 Where to go from here
 =========================
 
-Congratulations, crafted-emacs is now set up for you to start your
+Congratulations, Crafted Emacs is now set up for you to start your
 configuration.
 
    Here are some pointers to get you started:
@@ -801,7 +801,7 @@ File: crafted-emacs.info,  Node: Using alternate package managers,  Next: The cu
 ====================================
 
 Not everyone will prefer to use Emacs’ built-in package manager,
-‘package.el’.  Using the package bundle modules from _Crafted Emacs_ is
+‘package.el’.  Using the package bundle modules from Crafted Emacs is
 still possible, however, you will potentially need to iterate over the
 ‘package-selected-packages’ list to perform the install for your package
 manager.  To help with that, the ‘crafted-package-config’ module
@@ -822,8 +822,8 @@ is installed (preferable in ‘early-init.el’):
 ‘package-selected-packages’.
 
    Note: This usage is simple in the sense full recipes are not used
-when using _Crafted Emacs_ package bundle modules.  The above
-essentially runs code like the following:
+when using Crafted Emacs package bundle modules.  The above essentially
+runs code like the following:
 
      (straight-use-package 'corfu)
 
@@ -838,12 +838,12 @@ would look like this:
      (load (expand-file-name "custom-modules/crafted-early-init-straight"
                              user-emacs-directory))
 
-   It is not required to use the _Crafted Emacs_ package bundle modules,
+   It is not required to use the Crafted Emacs package bundle modules,
 you are free to install packages in whatever manner you choose, for
 example, using ‘guix-home’ to install Emacs packages from the Guix
 Store.  Similarly, using ‘straight’, ‘elpaca’, ‘package-vc’ or others
 can be used to install any packages you choose.  Once your packages are
-installed, you can then use the _Crafted Emacs_ configuration modules.
+installed, you can then use the Crafted Emacs configuration modules.
 These modules have names like ‘crafted-completion-config.el’ for
 example.  Add these to your ‘init.el’ *after* installing packages.
 
@@ -933,7 +933,7 @@ values configured than just these.
       )
 
 
-Listing 5.1: Example auto-generated ‘custom.el’ file.
+Listing 5.1: Example auto-generated file.
 
 
 File: crafted-emacs.info,  Node: Contributing,  Next: Modules,  Prev: Customization,  Up: Top
@@ -1045,7 +1045,7 @@ cape (https://github.com/minad/cape)                   provides completion at po
 go through them step by step.  For each step, imagine you want to switch
 buffers but you neither remember the binding nor the command to do that.
 Neither do you remember that the command starts with "switch".  But
-you’re sure it was something with buffers, so you hit "M-x" and type
+you’re sure it was something with buffers, so you hit ‘M-x’ and type
 ‘buf’.
 
    A fresh Emacs install would actually be pretty helpful for that
@@ -1124,7 +1124,7 @@ the packages of these module come in.
      The module ‘crafted-completion’ sets three consult functions for
      you that fit into the completion behaviour described above.
 
-        • Search-/filtering candidates and bind "C-s" to ‘consult-line’
+        • Search-/filtering candidates and bind ‘C-s’ to ‘consult-line’
           Whenever you’re presented with candidates for completions,
           consult provides a filtering search function which updates not
           only the list of candidates in the minibuffer, but also the
@@ -1138,7 +1138,7 @@ the packages of these module come in.
  [image src="img/06-consult-line.png" ]
 
 
-        • Bind "C-r" in the minibuffer to ‘consult-history’
+        • Bind ‘C-r’ in the minibuffer to ‘consult-history’
 
           Whenever you’re presented with candidates for completions in a
           minibuffer, ‘consult’ automatically sorts your most recently
@@ -1179,8 +1179,8 @@ the packages of these module come in.
 
         • ‘embark-act’
 
-          The ‘embark-act’ function (bound to "C-.")  offers you a lot
-          of possible actions that can be applied to the element of the
+          The ‘embark-act’ function (bound to ‘C-.’) offers you a lot of
+          possible actions that can be applied to the element of the
           buffer (or minibuffer) in which your cursor is positioned.
           You can think of this as a context menu, similar to what you
           achieve in many user interfaces by right-clicking on
@@ -1200,10 +1200,10 @@ the packages of these module come in.
 
           For one last time, imagine you want so switch buffers and have
           forgotten how.  But this time, you also remember that there
-          was a binding for it, probably starting with "C-x".
+          was a binding for it, probably starting with ‘C-x’.
 
-          You can hit "C-x C-h" to see a list of possible bindings after
-          the "C-x" prefix.  But you don’t need to cycle through them,
+          You can hit ‘C-x C-h’ to see a list of possible bindings after
+          the ‘C-x’ prefix.  But you don’t need to cycle through them,
           you can fuzzy-filter them.  Type "buf" to see only the
           bindings that relate to buffers.
 
@@ -1462,7 +1462,7 @@ you use.
 
           (customize-set-variable 'tab-always-indent nil)
 
-   • ‘completion-cycle-threshold’ : ‘3’
+   • ‘completion-cycle-threshold’ : 3
 
      When selection completion candidates, setting this variable uses
      cycling, i.e.  completing each of the candidates in turn.  This set
@@ -1657,7 +1657,7 @@ File: crafted-emacs.info,  Node: Persistence,  Next: Windows,  Prev: Navigation,
 
           (savehist-mode -1)
 
-   • ‘bookmark-save-flag’ : ‘1’
+   • ‘bookmark-save-flag’ : 1
 
      Save bookmarks to file every time you make or delete a bookmark.
 
@@ -1923,23 +1923,23 @@ File: crafted-emacs.info,  Node: Description (2),  Prev: Installation (2),  Up: 
 The ‘crafted-evil’ module adds ‘evil-mode’ alongside configuration to
 enhance the experience.
 
-   • ‘Package: evil’
+   • Package: ‘evil’
 
      Introduces the ‘evil-mode’ minor mode that adds vim-like modal
      editing, visual selection and text objects to Emacs.
 
-   • ‘Package: evil-collection’
+   • Package: ‘evil-collection’
 
      vim-like bindings for modes not covered by the ‘evil’ package.
      Automatically initialized for all common modes (see
      ‘evil-collection-mode-list’).
 
-   • ‘Package: evil-nerd-commenter’
+   • Package: ‘evil-nerd-commenter’
 
      Allow easy commenting of code for many different file types.  Is
      enabled with the default keybindings.
 
-   • ‘Package: undo-tree’
+   • Package: ‘undo-tree’
 
      This package is only installed for Emacs 28 or older.  With Emacs
      29 onwards, ‘undo-redo’ is used instead.  Both systems provide
@@ -2014,11 +2014,11 @@ enhance the experience.
      handled by ‘evil-collection’ (see above).  If the latter is _not_
      installed, this module provides three keybindings:
 
-     "C-j"   ‘vertico-next’
-     "C-k"   ‘vertico-previous’
-     "M-h"   ‘vertico-directory-up’
+     ‘C-j’   ‘vertico-next’
+     ‘C-k’   ‘vertico-previous’
+     ‘M-h’   ‘vertico-directory-up’
 
-     To change this, add code like this to you config, replacing "C-j"
+     To change this, add code like this to you config, replacing ‘C-j’
      with the desired keybinding:
 
           (keymap-set vertico-map "C-j" 'vertico-next)
@@ -2150,7 +2150,7 @@ development using various Lisp and Scheme variants.
    • ‘aggressive-indent-mode’ for all Lisp/Scheme modes
 
      ‘aggressive-indent’ automatically indents code, even while editing
-     or moving code around.  aggressive-indent-mode is added to
+     or moving code around.  ‘aggressive-indent-mode’ is added to
      ‘lisp-mode-hook’, ‘scheme-mode-hook’ and ‘clojure-mode-hook’.
 
   1. Common Lisp
@@ -2218,12 +2218,12 @@ development using various Lisp and Scheme variants.
 
 File: crafted-emacs.info,  Node: Additional packages geiser-*,  Prev: Description (4),  Up: Crafted Emacs Lisp Module
 
-7.5.3 Additional packages: geiser-*
------------------------------------
+7.5.3 Additional packages: ‘geiser-*’
+-------------------------------------
 
-‘Crafted Emacs’ pre-installs the geiser interface packages for ‘guile’
-and ‘racket’.  Additional geiser packages are usually named in the form
-of ‘geiser-<implementation>’, for example:
+Crafted Emacs pre-installs the geiser interface packages for guile and
+racket.  Additional geiser packages are usually named in the form of
+‘geiser-<implementation>’, for example:
 
    • ‘geiser-chez’ for Chez Scheme
    • ‘geiser-chibi’ for Chibi Scheme
@@ -2314,7 +2314,7 @@ enhance the experience.
      auto-pairing.  It is attached to both hooks to ensure the predicate
      is set up properly no matter which order the mode-hooks are run.
 
-   • ‘Package: denote’
+   • Package: ‘denote’
 
      Denote is a simple note-taking system for Emacs.  It is entirely
      based around file-naming conventions.
@@ -2322,7 +2322,7 @@ enhance the experience.
      It works with org, markdown and even basic text (txt) notes.  If
      you have denote installed, *note denote: (denote)Top.
 
-   • ‘Package: org-appear’
+   • Package: ‘org-appear’
 
      org-appear automatically toggles the appearance of certain elements
      in org-mode when editing in the surrounded region.  This is
@@ -2465,7 +2465,7 @@ File: crafted-emacs.info,  Node: Description (7),  Prev: Installation (7),  Up: 
 7.8.2 Description
 -----------------
 
-   • ‘Package: keycast’
+   • Package: ‘keycast’
 
      Package to show current command and its binding in the modeline or
      in the tab-bar.  By default, activates keycast in the modeline.
@@ -2557,7 +2557,7 @@ for viewing file-trees, currently open buffers and more.
                                    (unsplittable . t)
                                    (left-fringe . 0)))
 
-   • ‘new keybinding’: ‘crafted-speedbar-switch-to-quick-buffers’ (‘b’)
+   • new keybinding: ‘crafted-speedbar-switch-to-quick-buffers’ (‘b’)
 
      Temporarily change speedbar into a buffer switching tool,
      displaying the currently open buffers.  Pressing ‘<enter>’ on a
@@ -2793,7 +2793,7 @@ idea not to load this module, but take care of updates manually.
                (require 'crafted-startup-config)
 
           If you don’t want to use the startup module, you can also run
-          ‘crafted-updates-check-for-latest’ in your init.el.  It will
+          ‘crafted-updates-check-for-latest’ in your ‘init.el’.  It will
           show a notification in the mini-buffer (and in ‘*Messages*’).
 
                (crafted-updates-check-for-latest)
@@ -2818,21 +2818,21 @@ idea not to load this module, but take care of updates manually.
 
           In fact that variable accepts a variety of strings describing
           intervals or points at time.  See the documentation for the
-          function ‘run-at-time’ (e.g.  by using C-h f) for more
+          function ‘run-at-time’ (e.g.  by using ‘C-h f’) for more
           examples.
 
        3. Manually
 
           If you want to manually check for Crafted Emacs updates, run
-          M-x ‘crafted-updates-check-for-latest’.
+          ‘M-x’ ‘crafted-updates-check-for-latest’.
 
           If _no_ updates are available, you’ll see the message "Crafted
           Emacs is up to date!"  in the mini-buffer.
 
           If updates are available, you’ll see "Crafted Emacs updates
-          are available!".  Then you can run M-x
+          are available!".  Then you can run ‘M-x’
           ‘crafted-updates-pull-latest’ to update your installation.  If
-          you want to have a look at the changes first, run M-x
+          you want to have a look at the changes first, run ‘M-x’
           ‘crafted-updates-show-latest’ before pulling the changes in.
 
 
@@ -2874,7 +2874,7 @@ The ‘crafted-workspaces’ module installs and sets up the tabspaces
 (https://github.com/mclear-tools/tabspaces) package to provide
 workspaces (think of them like tabs in a web browser) for Emacs.
 
-   To open new workspaces, run M-x
+   To open new workspaces, run ‘M-x’
 ‘tabspaces-switch-or-create-workspace’.
 
    This module sets it up so that when changing buffers, you don’t see
@@ -2958,7 +2958,7 @@ production with markup languages like Markdown or LaTeX.
      configuration to quickly and easily set up whitespace mode, either
      globally or with mode-specific configurations:
 
-       1. Function ‘crafted-writing-configure-whitespace‘
+       1. Function ‘crafted-writing-configure-whitespace’
 
             1. Signature
 
@@ -2967,16 +2967,16 @@ production with markup languages like Markdown or LaTeX.
 
             2. Parameters
 
-               ‘use-tabs‘ (Type: Boolean)
+               ‘use-tabs’ (Type: Boolean)
                     Specifies whether to use tabs for indentation.  If
                     true, tabs are used; if false, spaces are used.
-               ‘use-globally‘ (Type: Boolean, Optional)
+               ‘use-globally’ (Type: Boolean, Optional)
                     Determines whether the whitespace configuration
                     should be applied globally or not.  If true, the
-                    configuration is applied globally; if false, the
+                    configuration is applied globally; if ‘nil’, the
                     configuration is applied only to the current buffer.
-                    Defaults to false if not specified.
-               ‘enabled-modes‘ (Type: List, Optional)
+                    Defaults to ‘nil’ if not specified.
+               ‘enabled-modes’ (Type: List, Optional)
                     List of modes to enable the configuration for.  The
                     configuration gets applied to all modes in the list.
                     If not specified, the configuration applies to all
@@ -3033,7 +3033,7 @@ production with markup languages like Markdown or LaTeX.
           The Emacs package provides an install script that can be run
           from inside emacs:
 
-          Run M-x ‘pdf-tools-install’.
+          Run ‘M-x’ ‘pdf-tools-install’.
 
           That will compile the backend for your system.  For many
           GNU/Linux distributions, the script also takes care of
@@ -3129,8 +3129,8 @@ these actions in your configuration:
 
         • Use ‘M-x package-list-packages’ to display the list of
           packages.
-        • Find the package in the list, press the letter ’D’ and the
-          letter ’X’ to uninstall that package.
+        • Find the package in the list, press the letter ‘D’ and the
+          letter ‘X’ to uninstall that package.
         • Restart Emacs, the package should be installed from MELPA thus
           using the development version of the package instead of the
           released version.
@@ -3181,111 +3181,111 @@ Node: Helps you learn Emacs Lisp8781
 Node: Reversible9316
 Node: Why use it?9587
 Node: Getting Started10264
-Node: Initial setup10870
-Node: Cleaning out your configuration directories11100
-Node: Cloning the repository12366
-Node: Bootstrapping Crafted Emacs13012
-Node: Early Emacs Initialization13381
-Node: Emacs Initialization17262
-Node: Crafted Emacs Modules19305
-Node: Installing packages19680
-Node: Using Crafted Emacs Modules21518
-Ref: Package definitions crafted-*-packages21996
-Ref: Configuration crafted-*-config22957
-Node: Example Configuration24131
-Node: To save or not to save customizations25391
-Node: Where to go from here28380
-Node: Customization29077
-Node: Using alternate package managers29309
-Node: The customel file31796
-Node: Simplified overview of how Emacs Customization works32189
-Node: Loading the customel file33907
-Ref: customel35080
-Node: Contributing35742
-Node: Modules36370
-Node: Crafted Emacs Completion Module37719
-Node: Installation37955
-Node: Description38484
-Ref: Vertico40868
-Ref: Orderless41578
-Ref: Marginalia42303
-Ref: Consult42668
-Ref: Embark45185
-Ref: Corfu46986
-Ref: Cape47769
-Node: Crafted Emacs Defaults Module48944
-Node: Installation (1)49364
-Node: Description (1)49834
-Node: Buffers50540
-Node: Completion54162
-Node: Editing57812
-Node: Navigation60776
-Node: Persistence61394
-Node: Windows63053
-Node: Miscellaneous68871
-Node: Acknowledgements70669
-Node: Crafted Emacs Evil Module71192
-Node: Installation (2)71476
-Node: Description (2)71983
-Node: Crafted Emacs IDE Module75774
-Node: Installation (3)76052
-Node: Description (3)76554
-Ref: Eglot77412
-Ref: Tree-Sitter77862
-Ref: Combobulate78065
-Node: Crafted Emacs Lisp Module78874
-Node: Installation (4)79186
-Node: Description (4)79693
-Ref: Common Lisp80287
-Ref: Clojure81153
-Ref: Scheme and Racket81789
-Node: Additional packages geiser-*82385
-Node: Crafted Emacs Org Module83439
-Node: Installation (5)83749
-Node: Description (5)84251
-Node: Alternative package org-roam86268
-Node: Crafted Emacs OSX Module88072
-Node: Installation (6)88355
-Node: Description (6)88667
-Node: Crafted Emacs Screencast Module89701
-Node: Installation (7)90003
-Node: Description (7)90540
-Node: Crafted Emacs Speedbar Module91223
-Node: Installation (8)91525
-Node: Description (8)91996
-Node: Crafted Emacs Startup Module94509
-Node: Installation (9)94803
-Node: Description (9)95273
-Node: Crafted Emacs UI Module96685
-Node: Installation (10)96970
-Node: Description (10)97471
-Ref: Icons with all-the-icons98142
-Ref: Line numbers98657
-Node: Crafted Emacs Updates Module99948
-Node: Installation (11)100246
-Node: Description (11)100718
-Ref: Usage and Customization101298
-Ref: On Startup101449
-Ref: Regularly102160
-Ref: Manually103087
-Node: Crafted Emacs Workspaces Module103690
-Node: Installation (12)103999
-Node: Description (12)104540
-Node: Crafted Emacs Writing Module106093
-Node: Installation (13)106359
-Node: Description (13)106885
-Ref: Whitespace Mode107412
-Ref: Function `crafted-writing-configure-whitespace`107878
-Ref: Signature107946
-Ref: Parameters108113
-Ref: Examples109022
-Ref: Optional Package PDF-Tools110131
-Ref: Part 1 Installing the Emacs package pdf-tools110477
-Ref: Part 2 Installing the epdfinfo-server110895
-Ref: Configuration111617
-Node: Troubleshooting112099
-Node: A package (suddenly?) fails to work112335
-Node: MIT License116123
+Node: Initial setup10866
+Node: Cleaning out your configuration directories11096
+Node: Cloning the repository12358
+Node: Bootstrapping Crafted Emacs13000
+Node: Early Emacs Initialization13367
+Node: Emacs Initialization17242
+Node: Crafted Emacs Modules19285
+Node: Installing packages19658
+Node: Using Crafted Emacs Modules21498
+Ref: Package definitions crafted-*-packages21974
+Ref: Configuration crafted-*-config22933
+Node: Example Configuration24111
+Node: To save or not to save customizations25371
+Node: Where to go from here28364
+Node: Customization29061
+Node: Using alternate package managers29293
+Node: The customel file31772
+Node: Simplified overview of how Emacs Customization works32165
+Node: Loading the customel file33883
+Ref: customel35056
+Node: Contributing35702
+Node: Modules36330
+Node: Crafted Emacs Completion Module37679
+Node: Installation37915
+Node: Description38444
+Ref: Vertico40832
+Ref: Orderless41542
+Ref: Marginalia42267
+Ref: Consult42632
+Ref: Embark45157
+Ref: Corfu46973
+Ref: Cape47756
+Node: Crafted Emacs Defaults Module48931
+Node: Installation (1)49351
+Node: Description (1)49821
+Node: Buffers50527
+Node: Completion54149
+Node: Editing57793
+Node: Navigation60757
+Node: Persistence61375
+Node: Windows63028
+Node: Miscellaneous68846
+Node: Acknowledgements70644
+Node: Crafted Emacs Evil Module71167
+Node: Installation (2)71451
+Node: Description (2)71958
+Node: Crafted Emacs IDE Module75765
+Node: Installation (3)76043
+Node: Description (3)76545
+Ref: Eglot77403
+Ref: Tree-Sitter77853
+Ref: Combobulate78056
+Node: Crafted Emacs Lisp Module78865
+Node: Installation (4)79177
+Node: Description (4)79684
+Ref: Common Lisp80284
+Ref: Clojure81150
+Ref: Scheme and Racket81786
+Node: Additional packages geiser-*82382
+Node: Crafted Emacs Org Module83426
+Node: Installation (5)83736
+Node: Description (5)84238
+Node: Alternative package org-roam86255
+Node: Crafted Emacs OSX Module88059
+Node: Installation (6)88342
+Node: Description (6)88654
+Node: Crafted Emacs Screencast Module89688
+Node: Installation (7)89990
+Node: Description (7)90527
+Node: Crafted Emacs Speedbar Module91210
+Node: Installation (8)91512
+Node: Description (8)91983
+Node: Crafted Emacs Startup Module94490
+Node: Installation (9)94784
+Node: Description (9)95254
+Node: Crafted Emacs UI Module96666
+Node: Installation (10)96951
+Node: Description (10)97452
+Ref: Icons with all-the-icons98123
+Ref: Line numbers98638
+Node: Crafted Emacs Updates Module99929
+Node: Installation (11)100227
+Node: Description (11)100699
+Ref: Usage and Customization101279
+Ref: On Startup101430
+Ref: Regularly102147
+Ref: Manually103080
+Node: Crafted Emacs Workspaces Module103701
+Node: Installation (12)104010
+Node: Description (12)104551
+Node: Crafted Emacs Writing Module106110
+Node: Installation (13)106376
+Node: Description (13)106902
+Ref: Whitespace Mode107429
+Ref: Function crafted-writing-configure-whitespace107895
+Ref: Signature107963
+Ref: Parameters108130
+Ref: Examples109047
+Ref: Optional Package PDF-Tools110156
+Ref: Part 1 Installing the Emacs package pdf-tools110502
+Ref: Part 2 Installing the epdfinfo-server110920
+Ref: Configuration111648
+Node: Troubleshooting112130
+Node: A package (suddenly?) fails to work112366
+Node: MIT License116154
 
 End Tag Table
 

--- a/docs/crafted-emacs.info
+++ b/docs/crafted-emacs.info
@@ -564,8 +564,8 @@ File: crafted-emacs.info,  Node: Installing packages,  Next: Using Crafted Emacs
 -------------------------
 
 The standard approach to finding and installing packages is to use the
-command ‘M-x’ ‘list-packages RET’, which will bring up a user interface
-to search for packages, review the package details, install, update or
+command ‘M-x list-packages’, which will bring up a user interface to
+search for packages, review the package details, install, update or
 remove package.  For more information: *note Packages: (emacs)Packages.
 or on the web: Packages
 (https://www.gnu.org/software/emacs/manual/html_node/emacs/Packages.html).
@@ -2696,7 +2696,7 @@ while leaving them turned off for others.
      exclamation mark at the beginning of this paragraph, you’re good to
      go.
 
-     If not, you can run M-x ‘all-the-icons-install-fonts’ to download
+     If not, you can run ‘M-x all-the-icons-install-fonts’ to download
      the necessary fonts.  On most OSes, they get installed
      automatically by that command.  On Windows however, they are only
      downloaded and must be installed manually.
@@ -2824,16 +2824,16 @@ idea not to load this module, but take care of updates manually.
        3. Manually
 
           If you want to manually check for Crafted Emacs updates, run
-          ‘M-x’ ‘crafted-updates-check-for-latest’.
+          ‘M-x crafted-updates-check-for-latest’.
 
           If _no_ updates are available, you’ll see the message "Crafted
           Emacs is up to date!"  in the mini-buffer.
 
           If updates are available, you’ll see "Crafted Emacs updates
-          are available!".  Then you can run ‘M-x’
-          ‘crafted-updates-pull-latest’ to update your installation.  If
-          you want to have a look at the changes first, run ‘M-x’
-          ‘crafted-updates-show-latest’ before pulling the changes in.
+          are available!".  Then you can run ‘M-x
+          crafted-updates-pull-latest’ to update your installation.  If
+          you want to have a look at the changes first, run ‘M-x
+          crafted-updates-show-latest’ before pulling the changes in.
 
 
 File: crafted-emacs.info,  Node: Crafted Emacs Workspaces Module,  Next: Crafted Emacs Writing Module,  Prev: Crafted Emacs Updates Module,  Up: Modules
@@ -2874,8 +2874,8 @@ The ‘crafted-workspaces’ module installs and sets up the tabspaces
 (https://github.com/mclear-tools/tabspaces) package to provide
 workspaces (think of them like tabs in a web browser) for Emacs.
 
-   To open new workspaces, run ‘M-x’
-‘tabspaces-switch-or-create-workspace’.
+   To open new workspaces, run ‘M-x
+tabspaces-switch-or-create-workspace’.
 
    This module sets it up so that when changing buffers, you don’t see
 the whole list of currently opened buffers, but only those that belong
@@ -3033,7 +3033,7 @@ production with markup languages like Markdown or LaTeX.
           The Emacs package provides an install script that can be run
           from inside emacs:
 
-          Run ‘M-x’ ‘pdf-tools-install’.
+          Run ‘M-x pdf-tools-install’.
 
           That will compile the backend for your system.  For many
           GNU/Linux distributions, the script also takes care of
@@ -3189,103 +3189,103 @@ Node: Early Emacs Initialization13367
 Node: Emacs Initialization17242
 Node: Crafted Emacs Modules19285
 Node: Installing packages19658
-Node: Using Crafted Emacs Modules21498
-Ref: Package definitions crafted-*-packages21974
-Ref: Configuration crafted-*-config22933
-Node: Example Configuration24111
-Node: To save or not to save customizations25371
-Node: Where to go from here28364
-Node: Customization29061
-Node: Using alternate package managers29293
-Node: The customel file31772
-Node: Simplified overview of how Emacs Customization works32165
-Node: Loading the customel file33883
-Ref: customel35056
-Node: Contributing35702
-Node: Modules36330
-Node: Crafted Emacs Completion Module37679
-Node: Installation37915
-Node: Description38444
-Ref: Vertico40832
-Ref: Orderless41542
-Ref: Marginalia42267
-Ref: Consult42632
-Ref: Embark45157
-Ref: Corfu46973
-Ref: Cape47756
-Node: Crafted Emacs Defaults Module48931
-Node: Installation (1)49351
-Node: Description (1)49821
-Node: Buffers50527
-Node: Completion54149
-Node: Editing57793
-Node: Navigation60757
-Node: Persistence61375
-Node: Windows63028
-Node: Miscellaneous68846
-Node: Acknowledgements70644
-Node: Crafted Emacs Evil Module71167
-Node: Installation (2)71451
-Node: Description (2)71958
-Node: Crafted Emacs IDE Module75765
-Node: Installation (3)76043
-Node: Description (3)76545
-Ref: Eglot77403
-Ref: Tree-Sitter77853
-Ref: Combobulate78056
-Node: Crafted Emacs Lisp Module78865
-Node: Installation (4)79177
-Node: Description (4)79684
-Ref: Common Lisp80284
-Ref: Clojure81150
-Ref: Scheme and Racket81786
-Node: Additional packages geiser-*82382
-Node: Crafted Emacs Org Module83426
-Node: Installation (5)83736
-Node: Description (5)84238
-Node: Alternative package org-roam86255
-Node: Crafted Emacs OSX Module88059
-Node: Installation (6)88342
-Node: Description (6)88654
-Node: Crafted Emacs Screencast Module89688
-Node: Installation (7)89990
-Node: Description (7)90527
-Node: Crafted Emacs Speedbar Module91210
-Node: Installation (8)91512
-Node: Description (8)91983
-Node: Crafted Emacs Startup Module94490
-Node: Installation (9)94784
-Node: Description (9)95254
-Node: Crafted Emacs UI Module96666
-Node: Installation (10)96951
-Node: Description (10)97452
-Ref: Icons with all-the-icons98123
-Ref: Line numbers98638
-Node: Crafted Emacs Updates Module99929
-Node: Installation (11)100227
-Node: Description (11)100699
-Ref: Usage and Customization101279
-Ref: On Startup101430
-Ref: Regularly102147
-Ref: Manually103080
-Node: Crafted Emacs Workspaces Module103701
-Node: Installation (12)104010
-Node: Description (12)104551
-Node: Crafted Emacs Writing Module106110
-Node: Installation (13)106376
-Node: Description (13)106902
-Ref: Whitespace Mode107429
-Ref: Function crafted-writing-configure-whitespace107895
-Ref: Signature107963
-Ref: Parameters108130
-Ref: Examples109047
-Ref: Optional Package PDF-Tools110156
-Ref: Part 1 Installing the Emacs package pdf-tools110502
-Ref: Part 2 Installing the epdfinfo-server110920
-Ref: Configuration111648
-Node: Troubleshooting112130
-Node: A package (suddenly?) fails to work112366
-Node: MIT License116154
+Node: Using Crafted Emacs Modules21488
+Ref: Package definitions crafted-*-packages21964
+Ref: Configuration crafted-*-config22923
+Node: Example Configuration24101
+Node: To save or not to save customizations25361
+Node: Where to go from here28354
+Node: Customization29051
+Node: Using alternate package managers29283
+Node: The customel file31762
+Node: Simplified overview of how Emacs Customization works32155
+Node: Loading the customel file33873
+Ref: customel35046
+Node: Contributing35692
+Node: Modules36320
+Node: Crafted Emacs Completion Module37669
+Node: Installation37905
+Node: Description38434
+Ref: Vertico40822
+Ref: Orderless41532
+Ref: Marginalia42257
+Ref: Consult42622
+Ref: Embark45147
+Ref: Corfu46963
+Ref: Cape47746
+Node: Crafted Emacs Defaults Module48921
+Node: Installation (1)49341
+Node: Description (1)49811
+Node: Buffers50517
+Node: Completion54139
+Node: Editing57783
+Node: Navigation60747
+Node: Persistence61365
+Node: Windows63018
+Node: Miscellaneous68836
+Node: Acknowledgements70634
+Node: Crafted Emacs Evil Module71157
+Node: Installation (2)71441
+Node: Description (2)71948
+Node: Crafted Emacs IDE Module75755
+Node: Installation (3)76033
+Node: Description (3)76535
+Ref: Eglot77393
+Ref: Tree-Sitter77843
+Ref: Combobulate78046
+Node: Crafted Emacs Lisp Module78855
+Node: Installation (4)79167
+Node: Description (4)79674
+Ref: Common Lisp80274
+Ref: Clojure81140
+Ref: Scheme and Racket81776
+Node: Additional packages geiser-*82372
+Node: Crafted Emacs Org Module83416
+Node: Installation (5)83726
+Node: Description (5)84228
+Node: Alternative package org-roam86245
+Node: Crafted Emacs OSX Module88049
+Node: Installation (6)88332
+Node: Description (6)88644
+Node: Crafted Emacs Screencast Module89678
+Node: Installation (7)89980
+Node: Description (7)90517
+Node: Crafted Emacs Speedbar Module91200
+Node: Installation (8)91502
+Node: Description (8)91973
+Node: Crafted Emacs Startup Module94480
+Node: Installation (9)94774
+Node: Description (9)95244
+Node: Crafted Emacs UI Module96656
+Node: Installation (10)96941
+Node: Description (10)97442
+Ref: Icons with all-the-icons98113
+Ref: Line numbers98628
+Node: Crafted Emacs Updates Module99919
+Node: Installation (11)100217
+Node: Description (11)100689
+Ref: Usage and Customization101269
+Ref: On Startup101420
+Ref: Regularly102137
+Ref: Manually103070
+Node: Crafted Emacs Workspaces Module103673
+Node: Installation (12)103982
+Node: Description (12)104523
+Node: Crafted Emacs Writing Module106076
+Node: Installation (13)106342
+Node: Description (13)106868
+Ref: Whitespace Mode107395
+Ref: Function crafted-writing-configure-whitespace107861
+Ref: Signature107929
+Ref: Parameters108096
+Ref: Examples109013
+Ref: Optional Package PDF-Tools110122
+Ref: Part 1 Installing the Emacs package pdf-tools110468
+Ref: Part 2 Installing the epdfinfo-server110886
+Ref: Configuration111608
+Node: Troubleshooting112090
+Node: A package (suddenly?) fails to work112326
+Node: MIT License116114
 
 End Tag Table
 

--- a/docs/crafted-emacs.org
+++ b/docs/crafted-emacs.org
@@ -99,15 +99,14 @@ file.
   this configuration are optional or interchangeable.
 
   You should even be able to use the configuration modules we provide
-  with your own ~init.el~ file without using this base configuration
+  with your own =init.el= file without using this base configuration
   repo!
 
 * Getting Started
 
-Welcome to @@texinfo:@emph{Crafted Emacs}@@.
+Welcome to Crafted Emacs.
 
-This section provides introductory material for setting up
-@@texinfo:@emph{Crafted Emacs}@@.
+This section provides introductory material for setting up Crafted Emacs.
 We'll approach this from the perspective of the brand new Emacs user.
 
 If you are already familiar with Emacs, you'll be able to skim this guide
@@ -119,17 +118,16 @@ for the code examples.
 
 ** Using alternate package managers
 
-  Not everyone will prefer to use Emacs' built-in package manager,
-  ~package.el~.  Using the package bundle modules from
-  @@texinfo:@emph{Crafted Emacs}@@ is still possible, however, you will
-  potentially need to iterate over the ~package-selected-packages~
-  list to perform the install for your package manager.  To help with
-  that, the ~crafted-package-config~ module provides a variable to set
-  and a function to call.
+  Not everyone will prefer to use Emacs' built-in package manager, ~package.el~.
+  Using the package bundle modules from Crafted Emacs is still possible,
+  however, you will potentially need to iterate over the
+  ~package-selected-packages~ list to perform the install for your package
+  manager. To help with that, the ~crafted-package-config~ module provides a
+  variable to set and a function to call.
 
   Here is an example using ~straight-use-package~ as the tool to install
   packages. The following lines must be called before any package is installed
-  (preferable in ~early-init.el~):
+  (preferable in =early-init.el=):
 
   #+begin_src emacs-lisp
     (load (expand-file-name "modules/crafted-package-config" crafted-emacs-home))
@@ -138,21 +136,21 @@ for the code examples.
     (setq crafted-package-installed-predicate #'straight--installed-p)
   #+end_src
 
-  In your ~init.el~ you have to call ~crafted-package-install-selected-packages~
+  In your =init.el= you have to call ~crafted-package-install-selected-packages~
   instead of ~package-install-selected-packages~, after adding your packages to
   ~package-selected-packages~.
 
-  Note: This usage is simple in the sense full recipes are not used
-  when using @@texinfo:@emph{Crafted Emacs}@@ package bundle modules.
-  The above essentially runs code like the following:
+  Note: This usage is simple in the sense full recipes are not used when using
+  Crafted Emacs package bundle modules. The above essentially runs code like the
+  following:
 
   #+begin_src emacs-lisp
     (straight-use-package 'corfu)
   #+end_src
 
   You find a full example [[file:../examples/crafted-early-init-straight.el][crafted-early-init-straight.el]] to bootstrap straight
-  in the examples directory. Merge it into your ~early-init.el~ or copy it to your
-  ~custom-modules~ folder. In the later case ~early-init.el~ would look like
+  in the examples directory. Merge it into your =early-init.el= or copy it to your
+  =custom-modules= folder. In the later case =early-init.el= would look like
   this:
 
   #+begin_src emacs-lisp
@@ -162,20 +160,18 @@ for the code examples.
                           user-emacs-directory))
   #+end_src
 
-  It is not required to use the @@texinfo:@emph{Crafted Emacs}@@
-  package bundle modules, you are free to install packages in whatever
-  manner you choose, for example, using ~guix-home~ to install Emacs
-  packages from the Guix Store.  Similarly, using ~straight~,
-  ~elpaca~, ~package-vc~ or others can be used to install any packages
-  you choose.  Once your packages are installed, you can then use the
-  @@texinfo:@emph{Crafted Emacs}@@ configuration modules.  These
-  modules have names like ~crafted-completion-config.el~ for example.
-  Add these to your ~init.el~ @@texinfo:@strong{after}@@ installing
-  packages.
+  It is not required to use the Crafted Emacs package bundle modules, you are
+  free to install packages in whatever manner you choose, for example, using
+  ~guix-home~ to install Emacs packages from the Guix Store. Similarly, using
+  ~straight~, ~elpaca~, ~package-vc~ or others can be used to install any packages you
+  choose. Once your packages are installed, you can then use the Crafted Emacs
+  configuration modules. These modules have names like
+  ~crafted-completion-config.el~ for example. Add these to your =init.el= *after*
+  installing packages.
 
-** The @@texinfo:@code{custom.el}@@ file
+** The =custom.el= file
 
-   The ~custom.el~ file will hold the auto-generated code from the Emacs
+   The =custom.el= file will hold the auto-generated code from the Emacs
    Customization UI.
 
 *** Simplified overview of how Emacs Customization works
@@ -188,31 +184,31 @@ for the code examples.
     consider two of them: the default state and the changed state. These are not
     the "official" names but easily convey the concepts of the variable. If a
     value is in the default state, looking in the Customization UI, the state
-    will be listed as ~STANDARD~. Crafted Emacs takes the approach of using the
-    ~customize-set-variable~ to update the values defined with
-    ~defcustom~. This will show the values as ~SET for current session only~ in
-    the Customization UI. This is normal since the values are set each time
-    Emacs starts. They are technically "SAVED" since they exist as emacs-lisp
-    code, but since they are not in a ~custom-set-variables~ form the
-    Customization UI only sees them as "SET for the current session only".
+    will be listed as =STANDARD=. Crafted Emacs takes the approach of using the
+    ~customize-set-variable~ to update the values defined with ~defcustom~. This
+    will show the values as =SET for current session only= in the Customization
+    UI. This is normal since the values are set each time Emacs starts. They are
+    technically "SAVED" since they exist as emacs-lisp code, but since they are
+    not in a ~custom-set-variables~ form the Customization UI only sees them as
+    "SET for the current session only".
 
-    A ~SAVED and set~ value means the Customization code has written the
+    A =SAVED and set= value means the Customization code has written the
     configuration to disk to be loaded again the next time Emacs starts. When
     Emacs saves the configuration from the Customization UI, it simply adds a
     couple of forms to the end of your initialization file (typically
-    ~init.el~), with comments warning about having more than one form with the
+    =init.el=), with comments warning about having more than one form with the
     same name (see example below).
 
-*** Loading the @@texinfo:@code{custom.el}@@ file
+*** Loading the =custom.el= file
 
     This is important because if you, the user, wish to use the Customization UI
     to configure Emacs, the customizations will (by default) be written to the
-    of the ~init.el~ file in a form called ~custom-set-variables~ and
+    of the =init.el= file in a form called ~custom-set-variables~ and
     ~custom-set-faces~. 
 
-    This snippet, added to the top of your ~init.el~ file sets the name of the
-    file holding Emacs customizations to be ~custom.el~ in the same directory
-    where your ~init.el~ file resides.  Additionally, the code checks to see if
+    This snippet, added to the top of your =init.el= file sets the name of the
+    file holding Emacs customizations to be =custom.el= in the same directory
+    where your =init.el= file resides.  Additionally, the code checks to see if
     the file exists, and if so, loads it to take advantage of the saved
     configuration therein.
     
@@ -228,7 +224,7 @@ for the code examples.
     configured than just these.
     
     #+name: custom.el
-    #+caption: Example auto-generated @@texinfo:@code{custom.el}@@ file.
+    #+caption: Example auto-generated =custom.el= file.
     #+begin_src emacs-lisp
       (custom-set-variables
        ;; custom-set-variables was added by Custom.
@@ -322,22 +318,22 @@ for the code examples.
    actions in your configuration:
 
    - Option 1
-     + Use ~M-x list-packages~ to display the list of packages.
+     + Use =M-x list-packages= to display the list of packages.
      + Find the package in the list which doesn't work for you, it will have
        either the /installed/ or /dependency/ status.
-     + Press the ~enter~ key to get more details on the package an look near the
+     + Press the =enter= key to get more details on the package an look near the
        bottom of the metadata, you should see a line with "Other Versions". Choose
        the development version - it will have a version number that looks like a
-       date and the text ~(melpa)~ next to it. Press ~enter~ on this version.
+       date and the text =(melpa)= next to it. Press =enter= on this version.
      + Following the step above will take you to the same package but from the
        MELPA repository, and you'll see a button at the top labeled
-       ~Install~. Click this button.
+       =Install=. Click this button.
      + *Optionally* you can go back to the list of packages, find previous
        installed version, press the letter 'D' and then the letter 'X' to
        uninstall that version.
      + Restart Emacs
    - Option 2
-     + Edit your ~early-config.el~ file.
+     + Edit your =early-config.el= file.
      + Near the bottom, add a line similar to this to pin the offending package
        to MELPA (make sure to replace /package-name/ with the name of the actual
        package):
@@ -346,16 +342,16 @@ for the code examples.
          (add-to-list 'package-pinned-packages (cons 'package-name "melpa"))
        #+end_src
 
-     + Use ~M-x package-list-packages~ to display the list of packages.
-     + Find the package in the list, press the letter 'D' and the letter 'X' to
+     + Use =M-x package-list-packages= to display the list of packages.
+     + Find the package in the list, press the letter =D= and the letter =X= to
        uninstall that package.
      + Restart Emacs, the package should be installed from MELPA thus using the
        development version of the package instead of the released version.
 
    Regardless, always feel free to open an issue here and we can help you
    out. Please be as complete as possible in your description of the
-   problem. Include any stack traces Emacs provides (ie start Emacs with: ~emacs
-   --debug-init~), mention the version number of the package you are installing,
+   problem. Include any stack traces Emacs provides (ie start Emacs with: =emacs
+   --debug-init=), mention the version number of the package you are installing,
    and anything you might have tried but which didn't work for you.
 
 * License
@@ -363,7 +359,7 @@ for the code examples.
   :COPYING:  t
   :END:
 
-  Copyright \copy 2022 System Crafters Community
+  Copyright \copy 2023 System Crafters Community
 
   #+caption: MIT License
   #+begin_quote

--- a/docs/crafted-evil.org
+++ b/docs/crafted-evil.org
@@ -18,105 +18,104 @@ points.
 
 ** Description
 
-=evil-mode= implements modal editing in the style of =vim= in Emacs.
-The =crafted-evil= module adds =evil-mode= alongside configuration to enhance
+~evil-mode~ implements modal editing in the style of =vim= in Emacs.
+The ~crafted-evil~ module adds ~evil-mode~ alongside configuration to enhance
 the experience.
 
-- =Package: evil=
+- Package: ~evil~
 
   Introduces the ~evil-mode~ minor mode that adds vim-like modal editing,
   visual selection and text objects to Emacs.
 
-- =Package: evil-collection=
+- Package: ~evil-collection~
 
   vim-like bindings for modes not covered by the ~evil~ package.
   Automatically initialized for all common modes
   (see ~evil-collection-mode-list~).
 
-- =Package: evil-nerd-commenter=
+- Package: ~evil-nerd-commenter~
 
   Allow easy commenting of code for many different file types.
   Is enabled with the default keybindings.
 
-- =Package: undo-tree=
+- Package: ~undo-tree~
 
-  This package is only installed for Emacs 28 or older.
-  With Emacs 29 onwards, =undo-redo= is used instead.
-  Both systems provide vim-like undo functionality and are selected for
-  ~evil-undo-system~ depending on the version of Emacs.
+  This package is only installed for Emacs 28 or older. With Emacs 29 onwards,
+  ~undo-redo~ is used instead. Both systems provide vim-like undo functionality
+  and are selected for ~evil-undo-system~ depending on the version of Emacs.
 
 
-- =evil-want-integration=: =t=
+- ~evil-want-integration~: =t=
 
-  Load the =evil-integration.el= file from evil-mode.
+  Load the ~evil-integration.el~ file from evil-mode.
   Provides additional integration for various Emacs modes.
 
-- =evil-want-keybinding=: =nil=
+- ~evil-want-keybinding~: =nil=
 
-  Disable keybinding integration, as it's covered by =evil-collection=.
+  Disable keybinding integration, as it's covered by ~evil-collection~.
 
-- =evil-want-C-i-jump=: =nil=
+- ~evil-want-C-i-jump~: =nil=
 
-  Disable vim's ~C-i~ jump.
+  Disable vim's =C-i= jump.
 
-- =evil-respect-visual-line-mode=: =t=
+- ~evil-respect-visual-line-mode~: =t=
 
   Respect visual-line-mode when moving around with vim movements.
 
-- =evil-want-C-h-delete=: =t=
+- ~evil-want-C-h-delete~: =t=
 
-  Enable a more ergonomic delete with ~C-h~ rather than having to reach for
+  Enable a more ergonomic delete with =C-h= rather than having to reach for
   the backspace key.
 
-- =evil-search-module=: =evil-search=
+- ~evil-search-module~: =evil-search=
 
   Make the evil search more like vim.
 
-- new binding: =C-g= \rightarrow =evil-normal-state=
+- new binding: =C-g= \rightarrow ~evil-normal-state~
 
-  Make ~C-g~ revert to normal state.
+  Make =C-g= revert to normal state.
 
-- new binding: =C-M-u= \rightarrow =universal-argument=
+- new binding: =C-M-u= \rightarrow ~universal-argument~
 
-  Rebind universal-argument to ~C-M-u~ since ~C-u~ is a vim binding to scroll
-  the buffer.
+  Rebind universal-argument to =C-M-u= since =C-u= is a vim binding to scroll the
+  buffer.
 
-- new evil bindings: =evil-*-visual-line=
+- new evil bindings: ~evil-*-visual-line~
 
-  Changes motion binds of ~j~ and ~k~ to use the ~visual-line~ functions, even
-  when outside ~visual-line-mode~ buffers.
+  Changes motion binds of =j= and =k= to use the ~visual-line~ functions, even when
+  outside ~visual-line-mode~ buffers.
 
-- new function: =crafted-evil-vim-muscle-memory=
+- new function: ~crafted-evil-vim-muscle-memory~
 
   Enable some of the default keybindings for evil mode to make the
   experience more like vim (C-i jump, Y-yank-to-eol, fine-undo).
   This function can be called after loading the configuration.
 
-- new function: =crafted-evil-discourage-arrow-keys=
+- new function: ~crafted-evil-discourage-arrow-keys~
 
   Replace arrow key functionality with a message to discourage use of
   arrow keys (and use "hjkl" instead).
   This function can be called after loading the configuration.
 
-- =evil-emacs-state-modes=
+- ~evil-emacs-state-modes~
 
   Some modes tend to not play nice with evil.
   These modes can be added to the ~evil-emacs-state-modes~ list for which
-  =evil-mode= will be falling back to Emacs-style keybindings and functionality.
+  ~evil-mode~ will be falling back to Emacs-style keybindings and functionality.
 
-  =crafted-evil= adds ~custom-mode~, ~eshell-mode~ and ~term-mode~.
+  ~crafted-evil~ adds ~custom-mode~, ~eshell-mode~ and ~term-mode~.
 
-- =vertico= - keybindings
+- ~vertico~ - keybindings
 
-  If =vertico= is installed and loaded, (e.g. by =crafted-completion-config=),
-  evil bindings for it are proably handled by =evil-collection= (see above). If
+  If ~vertico~ is installed and loaded, (e.g. by ~crafted-completion-config~),
+  evil bindings for it are proably handled by ~evil-collection~ (see above). If
   the latter is /not/ installed, this module provides three keybindings:
 
-  | "C-j" | =vertico-next=         |
-  | "C-k" | =vertico-previous=     |
-  | "M-h" | =vertico-directory-up= |
+  | =C-j= | ~vertico-next~         |
+  | =C-k= | ~vertico-previous~     |
+  | =M-h= | ~vertico-directory-up~ |
 
-  To change this, add code like this to you config, replacing "C-j" with the
+  To change this, add code like this to you config, replacing =C-j= with the
   desired keybinding:
 
   #+begin_src emacs-lisp

--- a/docs/crafted-ide.org
+++ b/docs/crafted-ide.org
@@ -18,32 +18,31 @@ points.
 
 ** Description
 
-The =crafted-ide= module sets up (and installs if necessary) functionality
-that makes Emacs act like a integrated development environment (IDE).
+The ~crafted-ide~ module sets up (and installs if necessary) functionality that
+makes Emacs act like a integrated development environment (IDE).
 
 It sets up project based buffer management ([[https://github.com/muffinmad/emacs-ibuffer-project][ibuffer-project]]) and a
-semi-automatic indentation ([[https://github.com/Malabarba/aggressive-indent-mode][aggressive-indent]]) for many programming and
-markup languages.
+semi-automatic indentation ([[https://github.com/Malabarba/aggressive-indent-mode][aggressive-indent]]) for many programming and markup
+languages.
 
 If you use [[https://editorconfig.org][EditorConfig]], this module provides support for that, too (see
 [[https://github.com/editorconfig/editorconfig-emacs][editorconfig-emacs]] for details).
 
-Furthermore, it sets up Eglot (a LSP-client) and Tree-Sitter (a next
-generation syntax parser).
+Furthermore, it sets up Eglot (a LSP-client) and Tree-Sitter (a next generation
+syntax parser).
 
 *** Eglot
 
-[[https://github.com/joaotavora/eglot][Eglot]] is a client for the Language Server Protocol (LSP) built into
-Emacs (>=29). For it to work, you have to have a LSP-Server installed for
-the language of your choice. Usually, these have to be installed through
-your operating system. See [[https://github.com/joaotavora/eglot#connecting-to-a-server][this list]] of servers that work with Eglot out
-of the box.
+[[https://github.com/joaotavora/eglot][Eglot]] is a client for the Language Server Protocol (LSP) built into Emacs
+(>=29). For it to work, you have to have a LSP-Server installed for the
+language of your choice. Usually, these have to be installed through your
+operating system. See [[https://github.com/joaotavora/eglot#connecting-to-a-server][this list]] of servers that work with Eglot out of the box.
 
 *** Tree-Sitter
 
 Tree-Sitter support (built-in since Emacs 29) enables Emacs to better
-understand the syntax of your code, thus improving syntax highlighting
-and similar functions.
+understand the syntax of your code, thus improving syntax highlighting and
+similar functions.
 
 **** Combobulate
 

--- a/docs/crafted-lisp.org
+++ b/docs/crafted-lisp.org
@@ -17,31 +17,29 @@ points.
 #+end_src
 
 ** Description
-The =crafted-lisp= module provides packages and configuration for development
+The ~crafted-lisp~ module provides packages and configuration for development
 using various Lisp and Scheme variants.
 
-- =aggressive-indent-mode= for all Lisp/Scheme modes
+- ~aggressive-indent-mode~ for all Lisp/Scheme modes
 
-  =aggressive-indent= automatically indents code, even while editing
-  or moving code around.
-  aggressive-indent-mode is added to =lisp-mode-hook=, =scheme-mode-hook=
-  and =clojure-mode-hook=.
+  ~aggressive-indent~ automatically indents code, even while editing or moving
+  code around. ~aggressive-indent-mode~ is added to ~lisp-mode-hook~,
+  ~scheme-mode-hook~ and ~clojure-mode-hook~.
 
 *** Common Lisp
 
-  The configuration for Common Lisp features Sylvester the cat’s
-  Common Lisp IDE for Emacs (=sly=).
-  The =sly-editing-mode= is added to the =lisp-mode-hook=.
+  The configuration for Common Lisp features Sylvester the cat’s Common Lisp IDE
+  for Emacs (~sly~). The ~sly-editing-mode~ is added to the ~lisp-mode-hook~.
 
   Sly provides a debugger, inspector, xref, completion, integration with
-  ASDF (=sly-asdf=) and Quicklisp (=sly-quicklisp=) system definition tools.
-  For ansi-color in the REPL, the package =sly-repl-ansi-color= is added.
+  ASDF (~sly-asdf~) and Quicklisp (~sly-quicklisp~) system definition tools.
+  For ansi-color in the REPL, the package ~sly-repl-ansi-color~ is added.
 
-  The sly extension packages (=sly-*=) are loaded once the main =sly= package
+  The sly extension packages (~sly-*~) are loaded once the main ~sly~ package
   is loaded.
 
-  To set the Common Lisp implementation, customize the
-  =inferior-lisp-program=, for example:
+  To set the Common Lisp implementation, customize the ~inferior-lisp-program~,
+  for example:
 
   #+begin_src emacs-lisp
   ;; SBCL
@@ -53,11 +51,11 @@ using various Lisp and Scheme variants.
 
 *** Clojure
 
-- Package: =cider=
+- Package: ~cider~
 
   Cider provides the REPL interface for Clojure in Emacs.
 
-- Package: =clj-refactor=
+- Package: ~clj-refactor~
 
   Additional refactoring layer built on-top of cider.
 
@@ -65,48 +63,48 @@ using various Lisp and Scheme variants.
   Crafted Emacs sets the bindings to =C-c r= by default to avoid this
   conflict.
 
-- Package: =clojure-mode=
+- Package: ~clojure-mode~
 
   Major mode for Clojure providing syntax highlighting, indentation
   and more.
 
-- Package: =flycheck-clojure=
+- Package: ~flycheck-clojure~
 
   Flycheck integration for Clojure linters.
 
 *** Scheme and Racket
 
-The Scheme and Racket configuration is entirely based around =geiser=.
+The Scheme and Racket configuration is entirely based around ~geiser~.
 
 Geiser provides a modular package for the Scheme family of languages
 including Racket. There are several modules availble for Geiser.
 When visiting a scheme file, use =M-x run-geiser= to start a REPL.
 
 If you have installed multiple scheme implementations, you may wish
-to customize the =scheme-program-name= variable.
+to customize the ~scheme-program-name~ variable.
 
 #+begin_src emacs-lisp
 ;; Default to guile (already in crafted-lisp-config.el)
 (customize-set-variable 'scheme-program-name "guile")
 #+end_src
 
-** Additional packages: geiser-*
+** Additional packages: ~geiser-*~
 
-=Crafted Emacs= pre-installs the geiser interface packages for =guile= and
-=racket=. Additional geiser packages are usually named in the form of
-=geiser-<implementation>=, for example:
+Crafted Emacs pre-installs the geiser interface packages for guile and racket.
+Additional geiser packages are usually named in the form of
+~geiser-<implementation>~, for example:
 
-- =geiser-chez= for Chez Scheme
-- =geiser-chibi= for Chibi Scheme
-- =geiser-chicken= for Chicken Scheme
-- =geiser-gambit= for Gambit Scheme
-- =geiser-gauche= for Gauche Scheme
-- =geiser-kawa= for GNU Kawa
-- =geiser-mit= for MIT/GNU Scheme
-- =stklos= for STklos
+- ~geiser-chez~ for Chez Scheme
+- ~geiser-chibi~ for Chibi Scheme
+- ~geiser-chicken~ for Chicken Scheme
+- ~geiser-gambit~ for Gambit Scheme
+- ~geiser-gauche~ for Gauche Scheme
+- ~geiser-kawa~ for GNU Kawa
+- ~geiser-mit~ for MIT/GNU Scheme
+- ~stklos~ for STklos
 
 All of these packages can be installed by adding them to the
-=package-selected-packages= list before installing all selected packages:
+~package-selected-packages~ list before installing all selected packages:
 
 #+begin_src emacs-lisp
 ;; Add support for MIT/GNU Scheme

--- a/docs/crafted-org.org
+++ b/docs/crafted-org.org
@@ -17,60 +17,59 @@ points.
 #+end_src
 
 ** Description
-The =crafted-org= module configures various settings related to =org-mode=
+The ~crafted-org~ module configures various settings related to ~org-mode~
 as well as installing a few additional related packages to enhance the
 experience.
 
-- =org-return-follows-link=: =t=
+- ~org-return-follows-link~: =t=
 
   Pressing =<RET>= while the cursor is over a link will follow the link.
 
-- =org-mouse-1-follows-link=: =t=
+- ~org-mouse-1-follows-link~: =t=
 
   Pressing =<Mouse 1>= (usually left-click) while the cursor is over a link
   will follow the link.
 
-- =org-link-descriptive=: =t=
+- ~org-link-descriptive~: =t=
 
   Display links in a prettified style, only showing the description
   (if provided).
 
-- New =org-mode-hook=: =org-indent-mode=
+- New ~org-mode-hook~: ~org-indent-mode~
 
   Visually indent org-mode files to a given header level.
 
-- =org-hide-emphasis-markers=: =t=
+- ~org-hide-emphasis-markers~: =t=
 
   Hides emphasis markers like =*bold*= or ==highlighted==.
 
-- New =org-mode-hook= and =electric-pair-mode-hook=:
+- New ~org-mode-hook~ and ~electric-pair-mode-hook~:
 
-  Adding a hook to setting the local =electric-pair-inhibit-predicate=
-  value to ignore =<= for auto-pairing.
-  It is attached to both hooks to ensure the predicate is set up properly
-  no matter which order the mode-hooks are run.
+  Adding a hook to setting the local ~electric-pair-inhibit-predicate~ value to
+  ignore =<= for auto-pairing. It is attached to both hooks to ensure the
+  predicate is set up properly no matter which order the mode-hooks are run.
 
-- =Package: denote=
+- Package: ~denote~
 
-  Denote is a simple note-taking system for Emacs. It is entirely based
-  around file-naming conventions.
+  Denote is a simple note-taking system for Emacs. It is entirely based around
+  file-naming conventions.
 
   It works with org, markdown and even basic text (txt) notes. If you have
   denote installed, [[info:denote][denote]].
 
-- =Package: org-appear=
+- Package: ~org-appear~
 
-  org-appear automatically toggles the appearance of certain elements
-  in org-mode when editing in the surrounded region. This is combined
-  with the org-mode setting =org-hide-emphasis-markers= to only show markers
-  when editing a region.
+  org-appear automatically toggles the appearance of certain elements in
+  org-mode when editing in the surrounded region. This is combined with the
+  org-mode setting ~org-hide-emphasis-markers~ to only show markers when editing a
+  region.
 
-  org-appear-mode is added as a hook to =org-mode-hook=, enabling when
+  org-appear-mode is added as a hook to ~org-mode-hook~, enabling when
   visiting an org-mode buffer.
 
 ** Alternative package: ~org-roam~
 
-=org-roam= is an alternative package option to =denote=. Compared to denote,
+~org-roam~ is an alternative package option to ~denote~. Compared to denote,
 it uses a SQLite database to organize notes and links. It requires a C
 compiler as an external dependency to interface with the database.
 

--- a/docs/crafted-osx.org
+++ b/docs/crafted-osx.org
@@ -21,11 +21,11 @@ to be set:
 
 | Keybinding | Meaning                          |
 |------------+----------------------------------|
-| ⌘-W       | (upper case W) delete-frame      |
-| ⌘-}       | tab-bar-switch-to-next-tab       |
-| ⌘-{       | tab-bar-switch-to-prev-tab       |
-| ⌘-t       | tab-bar-new-tab                  |
-| ⌘-w       | (lower case w) tab-bar-close-tab |
+| ⌘-W        | (upper case W) delete-frame      |
+| ⌘-}        | tab-bar-switch-to-next-tab       |
+| ⌘-{        | tab-bar-switch-to-prev-tab       |
+| ⌘-t        | tab-bar-new-tab                  |
+| ⌘-w        | (lower case w) tab-bar-close-tab |
 |------------+----------------------------------|
 
 We provide a function to set the frame titlebar transparent.  You call

--- a/docs/crafted-osx.org
+++ b/docs/crafted-osx.org
@@ -12,7 +12,7 @@ points.
 
 ** Description
 
-The =crafted-osx= module provides customizations to make Emacs more
+The ~crafted-osx~ module provides customizations to make Emacs more
 friendly on a Mac.  These largely have to do with keybindings as the
 Mac has a few keys different from a Linux or Windows computer.
 
@@ -21,11 +21,11 @@ to be set:
 
 | Keybinding | Meaning                          |
 |------------+----------------------------------|
-| ⌘-W        | (upper case W) delete-frame      |
-| ⌘-}        | tab-bar-switch-to-next-tab       |
-| ⌘-{        | tab-bar-switch-to-prev-tab       |
-| ⌘-t        | tab-bar-new-tab                  |
-| ⌘-w        | (lower case w) tab-bar-close-tab |
+| ⌘-W       | (upper case W) delete-frame      |
+| ⌘-}       | tab-bar-switch-to-next-tab       |
+| ⌘-{       | tab-bar-switch-to-prev-tab       |
+| ⌘-t       | tab-bar-new-tab                  |
+| ⌘-w       | (lower case w) tab-bar-close-tab |
 |------------+----------------------------------|
 
 We provide a function to set the frame titlebar transparent.  You call

--- a/docs/crafted-screencast.org
+++ b/docs/crafted-screencast.org
@@ -18,17 +18,17 @@ points.
 
 ** Description
 
-- =Package: keycast=
+- Package: ~keycast~
 
   Package to show current command and its binding in the modeline or
   in the tab-bar. By default, activates keycast in the modeline.
 
-- =keycast-remove-tail-elements=: =nil=
+- ~keycast-remove-tail-elements~: =nil=
 
   By default, keycast-mode removes the elements to the right of the modeline.
   This may obscure information, so we'll disable it.
 
-- =keycast-insert-after=: =mode-line-misc-info=
+- ~keycast-insert-after~: =mode-line-misc-info=
 
   Insert keycast information after ~mode-line-misc-info~ in the
   ~mode-line-format~.

--- a/docs/crafted-speedbar.org
+++ b/docs/crafted-speedbar.org
@@ -20,7 +20,7 @@ points.
 Speedbar is a tree-like view model built-in to Emacs.
 It can be used for viewing file-trees, currently open buffers and more.
 
-- =speedbar-update-flag=: =t=
+- ~speedbar-update-flag~: =t=
 
   Update the speedbar view if the directory of the attached frame changes.
 
@@ -31,7 +31,7 @@ It can be used for viewing file-trees, currently open buffers and more.
   (setq-default speedbar-update-flag nil)
   #+end_src
 
-- =speedbar-use-images=: =nil=
+- ~speedbar-use-images~: =nil=
 
   Speedbar uses small images for directories, files and file-local structures,
   however in many configurations they turn out pixelated or don't fit the theme.
@@ -43,9 +43,9 @@ It can be used for viewing file-trees, currently open buffers and more.
   (setq-default speedbar-use-images t)
   #+end_src
 
-- =speedbar-frame-parameters=
+- ~speedbar-frame-parameters~
 
-  Customizing =speedbar-frame-parameters= sets additional frame parameters
+  Customizing ~speedbar-frame-parameters~ sets additional frame parameters
   for speedbar frames.
 
   Crafted Emacs adds a frame name/title, removes the minibuffer status
@@ -64,7 +64,7 @@ It can be used for viewing file-trees, currently open buffers and more.
                            (left-fringe . 0)))
   #+end_src
 
-- =new keybinding=: =crafted-speedbar-switch-to-quick-buffers= (=b=)
+- new keybinding: ~crafted-speedbar-switch-to-quick-buffers~ (=b=)
 
   Temporarily change speedbar into a buffer switching tool,
   displaying the currently open buffers.
@@ -78,7 +78,7 @@ It can be used for viewing file-trees, currently open buffers and more.
               #'crafted-speedbar-switch-to-quick-buffers)
   #+end_src
 
-- =speedbar-add-supported-extension=: new extensions
+- ~speedbar-add-supported-extension~: new extensions
 
   Crafted Emacs adds a wide selection of file extensions that support
   tagging to speedbar's tagging system.

--- a/docs/crafted-startup.org
+++ b/docs/crafted-startup.org
@@ -17,36 +17,34 @@ points.
 
 ** Description
 
-The =crafted-startup= module provides a fancy splash screen similar to the Emacs
+The ~crafted-startup~ module provides a fancy splash screen similar to the Emacs
 default splash screen or the Emacs about page.
 
-If it is used together with the =crafted-updates= module, it will also check for
+If it is used together with the ~crafted-updates~ module, it will also check for
 updates during startup and will display the options to preview and install
-updates on the splash screen. To use this, simply require =crafted-updates-config=
-alongside this module:
+updates on the splash screen. To use this, simply require
+~crafted-updates-config~ alongside this module:
 
 #+begin_src emacs-lisp
   (require 'crafted-startup-config)
   (require 'crafted-updates-config)
   #+end_src
-
   
-If the list =recentf-list= is not empty, the splash screen will display the most
+If the list ~recentf-list~ is not empty, the splash screen will display the most
 recent entries of that list as links. By default, the most recent 10 entries
 in that list are displayed. You can modify this behaviour by setting
-=crafted-startup-recentf-count= in your config, for example:
+~crafted-startup-recentf-count~ in your config, for example:
 
 #+begin_src emacs-lisp
   (customize-set-variable 'crafted-startup-recentf-count 3)
 #+end_src
 
-See the documentation for =recentf-mode= for details about the list.
-
+See the documentation for ~recentf-mode~ for details about the list.
 
 If you want to turn off the splash screen altogether, you can either choose
 not to load the module at all. Or, e.g. if you want to use the check for updates
 during startup but not the splash screen, you can set
-=crafted-startup-inhibit-splash= to non-nil.
+~crafted-startup-inhibit-splash~ to non-nil.
 
 #+begin_src emacs-lisp
   (customize-set-variable 'crafted-startup-inhibit-splash t)

--- a/docs/crafted-ui.org
+++ b/docs/crafted-ui.org
@@ -17,7 +17,7 @@ points.
 #+end_src
 
 ** Description
-The =crafted-ui= module provides a few interface customizations.
+The ~crafted-ui~ module provides a few interface customizations.
 
 It installs the packages
 
@@ -27,12 +27,12 @@ It installs the packages
 - elisp-demos :: Code examples that can be displayed by helpful.
 
 It further provides custom variables which can be used to turn on line
-numbers in certain major modes (i.e. =prog-mode= and =conf-mode=) while leaving
+numbers in certain major modes (i.e. ~prog-mode~ and ~conf-mode~) while leaving
 them turned off for others.   
 
-*** Icons with =all-the-icons=
+*** Icons with ~all-the-icons~
 
- For =all-the-icons= to work, the necessary fonts need to be installed on
+ For ~all-the-icons~ to work, the necessary fonts need to be installed on
 your system. If you see a "stop"-icon with an exclamation mark at the
 beginning of this paragraph, you're good to go.
 

--- a/docs/crafted-ui.org
+++ b/docs/crafted-ui.org
@@ -36,7 +36,7 @@ them turned off for others.
 your system. If you see a "stop"-icon with an exclamation mark at the
 beginning of this paragraph, you're good to go.
 
-If not, you can run M-x ~all-the-icons-install-fonts~ to download the
+If not, you can run =M-x all-the-icons-install-fonts= to download the
 necessary fonts. On most OSes, they get installed automatically by that
 command. On Windows however, they are only downloaded and must be
 installed manually.

--- a/docs/crafted-updates.org
+++ b/docs/crafted-updates.org
@@ -79,12 +79,12 @@ using =C-h f=) for more examples.
 **** Manually
 
 If you want to manually check for Crafted Emacs updates, run
-=M-x= ~crafted-updates-check-for-latest~.
+=M-x crafted-updates-check-for-latest=.
 
 If /no/ updates are available, you'll see the message "Crafted Emacs is up to
 date!" in the mini-buffer.
 
 If updates are available, you'll see "Crafted Emacs updates are available!".
-Then you can run =M-x= ~crafted-updates-pull-latest~ to update your installation.
-If you want to have a look at the changes first, run =M-x=
-~crafted-updates-show-latest~ before pulling the changes in.
+Then you can run =M-x crafted-updates-pull-latest= to update your installation.
+If you want to have a look at the changes first, run
+=M-x crafted-updates-show-latest= before pulling the changes in.

--- a/docs/crafted-updates.org
+++ b/docs/crafted-updates.org
@@ -17,7 +17,7 @@ points.
 
 ** Description
 
-The =crafted-updates= module provides functionality to check for updates of
+The ~crafted-updates~ module provides functionality to check for updates of
 Crafted Emacs. To do so, it relies on [[https://git-scm.com/][git]]. It will only work if you cloned the
 Crafted Emacs [[https://github.com/SystemCrafters/crafted-emacs][github repository]] to your machine.
 
@@ -31,7 +31,7 @@ regularly and manually.
 
 **** On Startup
 
-This is probably the easiest way. Just load the module =crafted-startup-config=
+This is probably the easiest way. Just load the module ~crafted-startup-config~
 alongside this module in your init.el. The update check will be run during
 every startup. If you also use the startup screen, a notification about updates
 will be shown there.
@@ -42,7 +42,7 @@ will be shown there.
 #+end_src
 
 If you don't want to use the startup module, you can also run
-=crafted-updates-check-for-latest= in your init.el. It will show a notification
+~crafted-updates-check-for-latest~ in your =init.el=. It will show a notification
 in the mini-buffer (and in =*Messages*=).
 
 #+begin_src emacs-lisp
@@ -51,7 +51,7 @@ in the mini-buffer (and in =*Messages*=).
 
 **** Regularly
 
-This module provides a minor mode =crafted-updates-mode=. When active, it will
+This module provides a minor mode ~crafted-updates-mode~. When active, it will
 check for updates regularly.
 
 Activate it in your config, e.g. in init.el:
@@ -60,7 +60,7 @@ Activate it in your config, e.g. in init.el:
 #+end_src
 
 By default, it checks for updates every 24 hours. You can customize this by
-modifying the variable =crafted-updates-fetch-interval=.
+modifying the variable ~crafted-updates-fetch-interval~.
 
 For example, if you want to check every 10 hours:
 #+begin_src emacs-lisp
@@ -73,18 +73,18 @@ You can also specify a specific time:
 #+end_src
 
 In fact that variable accepts a variety of strings describing intervals or
-points at time. See the documentation for the function =run-at-time= (e.g. by
-using C-h f) for more examples.
+points at time. See the documentation for the function ~run-at-time~ (e.g. by
+using =C-h f=) for more examples.
 
 **** Manually
 
 If you want to manually check for Crafted Emacs updates, run
-M-x =crafted-updates-check-for-latest=.
+=M-x= ~crafted-updates-check-for-latest~.
 
 If /no/ updates are available, you'll see the message "Crafted Emacs is up to
 date!" in the mini-buffer.
 
 If updates are available, you'll see "Crafted Emacs updates are available!".
-Then you can run M-x =crafted-updates-pull-latest= to update your
-installation. If you want to have a look at the changes first, run
-M-x =crafted-updates-show-latest= before pulling the changes in. 
+Then you can run =M-x= ~crafted-updates-pull-latest~ to update your installation.
+If you want to have a look at the changes first, run =M-x=
+~crafted-updates-show-latest~ before pulling the changes in.

--- a/docs/crafted-workspaces.org
+++ b/docs/crafted-workspaces.org
@@ -21,7 +21,7 @@ points.
 The ~crafted-workspaces~ module installs and sets up the [[https://github.com/mclear-tools/tabspaces][tabspaces]] package
 to provide workspaces (think of them like tabs in a web browser) for Emacs.
 
-To open new workspaces, run =M-x= ~tabspaces-switch-or-create-workspace~.
+To open new workspaces, run =M-x tabspaces-switch-or-create-workspace=.
 
 This module sets it up so that when changing buffers, you don't see the
 whole list of currently opened buffers, but only those that belong to the

--- a/docs/crafted-workspaces.org
+++ b/docs/crafted-workspaces.org
@@ -18,10 +18,10 @@ points.
 
 ** Description
 
-The =crafted-workspaces= module installs and sets up the [[https://github.com/mclear-tools/tabspaces][tabspaces]] package
+The ~crafted-workspaces~ module installs and sets up the [[https://github.com/mclear-tools/tabspaces][tabspaces]] package
 to provide workspaces (think of them like tabs in a web browser) for Emacs.
 
-To open new workspaces, run M-x ~tabspaces-switch-or-create-workspace~.
+To open new workspaces, run =M-x= ~tabspaces-switch-or-create-workspace~.
 
 This module sets it up so that when changing buffers, you don't see the
 whole list of currently opened buffers, but only those that belong to the
@@ -39,7 +39,7 @@ When you remove a buffer from all opened workspaces, it will still be open
 and available from your default workspace. You can modify that behaviour by
 setting the custom variable ~tabspaces-remove-to-default~ to nil.
 
-By default the ~*scratch*~ buffer is accessible from all workspaces. You can
+By default the =*scratch*= buffer is accessible from all workspaces. You can
 modify which buffers are included by default by changing the value of
 ~tabspaces-include-buffers~.
 

--- a/docs/crafted-writing.org
+++ b/docs/crafted-writing.org
@@ -17,18 +17,18 @@ points.
 #+end_src
 
 ** Description
-The =crafted-writing= module configures various settings related to text
+The ~crafted-writing~ module configures various settings related to text
 production with markup languages like Markdown or LaTeX.
 
 It installs and sets up following packages:
-- =markdown-mode=
-- =pandoc-mode=
-- =auctex= (if LaTeX is installed on your system)
-- =auctex-latexmk= (if =latexmk= is installed on your system)
+- ~markdown-mode~
+- ~pandoc-mode~
+- ~auctex~ (if LaTeX is installed on your system)
+- ~auctex-latexmk~ (if ~latexmk~ is installed on your system)
 
 *** Whitespace Mode
 
-This module also provides a configuration for =whitespace-mode=, which
+This module also provides a configuration for ~whitespace-mode~, which
 visualizes whitespace characters like spaces and tabs. This is especially
 useful for major modes with meaningful whitespace, like e.g. Makefiles.
 
@@ -36,7 +36,7 @@ This module provides the handy function that can be used in your configuration
 to quickly and easily set up whitespace mode, either globally or with
 mode-specific configurations:
 
-**** Function `crafted-writing-configure-whitespace`
+**** Function ~crafted-writing-configure-whitespace~
 
 ***** Signature
 
@@ -47,13 +47,13 @@ mode-specific configurations:
 
 ***** Parameters
 
-- `use-tabs` (Type: Boolean) :: Specifies whether to use tabs for indentation.
+- ~use-tabs~ (Type: Boolean) :: Specifies whether to use tabs for indentation.
   If true, tabs are used; if false, spaces are used.
-- `use-globally` (Type: Boolean, Optional) :: Determines whether the whitespace
+- ~use-globally~ (Type: Boolean, Optional) :: Determines whether the whitespace
   configuration should be applied globally or not. If true, the configuration
-  is applied globally; if false, the configuration is applied only to the
-  current buffer. Defaults to false if not specified.
-- `enabled-modes` (Type: List, Optional) ::  List of modes to enable the
+  is applied globally; if =nil=, the configuration is applied only to the
+  current buffer. Defaults to =nil= if not specified.
+- ~enabled-modes~ (Type: List, Optional) ::  List of modes to enable the
   configuration for. The configuration gets applied to all modes in the list.
   If not specified, the configuration applies to all modes.
 
@@ -70,7 +70,7 @@ Or to enable whitespace-mode only for Makefiles, using tabs:
 #+end_src
 
 *Please Note:* These two uses of the functions overwrite each other.
-So if you want to have =whitespace-mode= active globally with spaces,
+So if you want to have ~whitespace-mode~ active globally with spaces,
 except for Makefiles, where you want to use tabs, use this
 configuration instead:
 
@@ -83,8 +83,8 @@ configuration instead:
   (add-hook 'makefile-mode-hook #'indent-tabs-mode)
 #+end_src
 
-For more information on `indent-tabs-mode', See the info
-node `(emacs)Just Spaces'
+For more information on ~indent-tabs-mode~, See the info
+node =(emacs)Just Spaces=
 
 *** Optional Package: PDF-Tools
 
@@ -93,10 +93,10 @@ just docview for rendering PDF files. It is not installed by default,
 however, because it involves a two-part installation process that
 varies depending on your OS.
 
-**** Part 1: Installing the Emacs package =pdf-tools=
+**** Part 1: Installing the Emacs package ~pdf-tools~
 
 Installing the front end in Emacs is simple, just use your package manager
-to install the package =pdf-tools=, e.g. by putting this in the packages
+to install the package ~pdf-tools~, e.g. by putting this in the packages
 phase of your =init.el= and running ~package-install-selected-packages~
 afterwards:
 
@@ -104,7 +104,7 @@ afterwards:
   (add-to-list 'package-selected-packages 'pdf-tools)
 #+end_src
 
-**** Part 2: Installing the =epdfinfo-server=
+**** Part 2: Installing the ~epdfinfo-server~
 
 PDF-Tools needs a backend to be run against, the epdfinfo-server.
 
@@ -112,7 +112,7 @@ The only OS officially supported by PDF-Tools is GNU/Linux. The
 Emacs package provides an install script that can be run from inside
 emacs:
 
-Run M-x ~pdf-tools-install~.
+Run =M-x= ~pdf-tools-install~.
 
 That will compile the backend for your system. For many GNU/Linux
 distributions, the script also takes care of installing the necessary
@@ -122,7 +122,7 @@ For other OSes and further info, see [[https://github.com/vedang/pdf-tools#insta
 
 **** Configuration
 
-If this module finds =pdf-tools= installed in your Emacs setup, it will
+If this module finds ~pdf-tools~ installed in your Emacs setup, it will
 add a hook to automatically load it when you view PDF documents. It will
 also adjust the view to fit the width of the document.
 

--- a/docs/crafted-writing.org
+++ b/docs/crafted-writing.org
@@ -112,7 +112,7 @@ The only OS officially supported by PDF-Tools is GNU/Linux. The
 Emacs package provides an install script that can be run from inside
 emacs:
 
-Run =M-x= ~pdf-tools-install~.
+Run =M-x pdf-tools-install=.
 
 That will compile the backend for your system. For many GNU/Linux
 distributions, the script also takes care of installing the necessary

--- a/docs/getting-started-guide.org
+++ b/docs/getting-started-guide.org
@@ -4,57 +4,55 @@
 
 First, we need to make sure we are starting with a clean slate.
 
-If you are starting from scratch, but have started Emacs already,
-you probably already have generated some amount of configuration files.
-For more information: [[info:emacs#Init File][Init File]], or on the web: [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Init-File.html][Init File]].
-If you're on Windows, also see [[info:emacs#Windows HOME][Windows HOME]], or on the web: [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Windows-HOME.html][Windows HOME]].
+If you are starting from scratch, but have started Emacs already, you probably
+already have generated some amount of configuration files. For more information:
+[[info:emacs#Init File][Init File]], or on the web: [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Init-File.html][Init File]]. If you're on Windows, also see [[info:emacs#Windows HOME][Windows
+HOME]], or on the web: [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Windows-HOME.html][Windows HOME]].
 
 You must decide if you wish to remove them or rename them to something else.
 
-If you aren't starting from scratch, then you probably have some
-configuration already working and you want to add or use some of the
-configuration found in @@texinfo:@emph{Crafted Emacs}@@.
-You probably have to adapt and rewrite parts of your configuration to
-work with @@texinfo:@emph{Crafted Emacs}@@.
+If you aren't starting from scratch, then you probably have some configuration
+already working and you want to add or use some of the configuration found in
+Crafted Emacs. You probably have to adapt and rewrite parts of your
+configuration to work with Crafted Emacs.
 
-Wherever you decide to put your Emacs configuration will be known
-as ~user-emacs-directory~ for the rest of this guide.
+Wherever you decide to put your Emacs configuration will be known as
+~user-emacs-directory~ for the rest of this guide.
 
 ** Cloning the repository
 
-To use @@texinfo:@emph{Crafted Emacs}@@,
-you will need to download the repository.
-It is up to you where you clone to.
-If you are not sure where to clone to, you can use your home directory.
+To use Crafted Emacs, you will need to download the repository. It is up to you
+where you clone to. If you are not sure where to clone to, you can use your home
+directory.
 
 #+begin_src shell
   # N.B. As this is still a beta release, use the craftedv2beta branch
   git clone https://github.com/SystemCrafters/crafted-emacs -b craftedv2beta
 #+end_src
 
-For the rest of this guide, the location where you cloned
-@@texinfo:@emph{Crafted Emacs}@@ to will be known as ~crafted-emacs-home~.
+For the rest of this guide, the location where you cloned Crafted Emacs to will
+be known as ~crafted-emacs-home~.
 
 * Bootstrapping Crafted Emacs
 
-After cloning the crafted-emacs repository,
-we need to let Emacs know how to load @@texinfo:@emph{Crafted Emacs}@@.
+After cloning the crafted-emacs repository, we need to let Emacs know how to
+load Crafted Emacs.
 
 ** Early Emacs Initialization
 
 The Emacs startup process has several steps, more than what will be
-discussed here. We will briefly cover the ~early-init.el~ file which Emacs
+discussed here. We will briefly cover the =early-init.el= file which Emacs
 allows user to affect some configuration options which occur before Emacs
 draws the initial frame (often known as the "window" in a graphical
-windowing system). For more information on ~early-init.el~ see
+windowing system). For more information on =early-init.el= see
 [[info:emacs#Early Init File][Early Init File]], or on the web: [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Early-Init-File.html][Early Init File]].
 
 For our purposes, this is where we initialize the package system.
 In the ~user-emacs-directory~:
 
-1. Create a file called ~early-init.el~
+1. Create a file called =early-init.el=
 2. Add this single line of code (which assumes the ~crafted-emacs-home~ is
-   the ~crafted-emacs~ directory found in your home folder):
+   the =crafted-emacs= directory found in your home folder):
 
 #+begin_src emacs-lisp
   (load "~/crafted-emacs/modules/crafted-early-init-config")
@@ -64,35 +62,35 @@ Loading ~crafted-early-init-config~ will do the following:
 
 - Setup the ~package-archives~ list to include the following list of
   package repositories:
-  1. @@texinfo:@strong{GNU Elpa}@@:
+  1. *GNU Elpa*:
      Contains packages which are licensed under the GNU GPL
      (GNU General Public License) and for which the author has signed
      the copyright release to the Free Software Foundation.
      The package archive is maintained by the GNU Emacs maintainers.
-  2. @@texinfo:@strong{Non-GNU Elpa}@@:
+  2. *Non-GNU Elpa*:
      Contains packages which are licensed as [[https://www.gnu.org/philosophy/free-sw.html][free software]] and for which
      authors have not signed the copyright release required for GNU Elpa.
      Authors must however follow a list of rules for package submission.
      The decision to include a package is left to the discretion of the
      GNU Emacs maintainers.
-  3. @@texinfo:@strong{MELPA Stable}@@:
+  3. *MELPA Stable*:
      MELPA is a community-authored package archive with a wide range of
      packages available.
      The stable repository contains packages which have a
      version tag in their ~git~ repository.
      These are pulled and built on a regular basis as needed
      when the tag version changes.
-  4. @@texinfo:@strong{MELPA}@@:
+  4. *MELPA*:
      Like MELPA Stable, but packages are based on the latest commit
      in the respective ~git~ repository (essentially, development versions).
      These will have version numbers similar to this:
-     ~20210701.839~ which is essentially a date stamp when
+     =20210701.839= which is essentially a date stamp when
      the package was built.
 - Prioritize the list of package repositories to be in the order
   listed above. This means, we prefer to get packages from GNU Elpa
   first, if not found, then try the next repository down the list,
   finally trying to get the package from MELPA as a last resort.
-  This is because @@texinfo:@emph{Crafted Emacs}@@ prefers released
+  This is because Crafted Emacs prefers released
   versions, if available, for all packages installed.
 - Check to make sure the repository cache archives are up-to-date,
   and update if needed.  This check is performed when Emacs is
@@ -100,21 +98,20 @@ Loading ~crafted-early-init-config~ will do the following:
   than one day. To check less frequently, set the variable
   ~crafted-package-update-days~ to a higher value.  To not perform
   the check at all, set the
-  ~crafted-package-perform-stale-archive-check~ variable to ~nil~.
+  ~crafted-package-perform-stale-archive-check~ variable to =nil=.
 
-Once @@texinfo:@emph{Crafted Emacs}@@ is up and running, no stale
-checks are made. Thus, if you run @@texinfo:@emph{Crafted Emacs}@@
-for several days without restarting Emacs, you'll need to
-refresh the package repository archive caches manually. This is
-done automatically when running ~package-list-packages~.
+Once Crafted Emacs is up and running, no stale checks are made. Thus, if you run
+Crafted Emacs for several days without restarting Emacs, you'll need to refresh
+the package repository archive caches manually. This is done automatically when
+running ~package-list-packages~.
 
 Outside of special use-cases, this single line of code will be
-your entire ~early-init.el~ file.
+your entire =early-init.el= file.
 
 ** Emacs Initialization
 
-The ~init.el~ file is where most of the work of configuring Emacs will
-occur. Let's start by creating the ~init.el~ file in your
+The =init.el= file is where most of the work of configuring Emacs will
+occur. Let's start by creating the =init.el= file in your
 ~user-emacs-directory~ and add this code:
 
 #+begin_src emacs-lisp
@@ -125,19 +122,18 @@ occur. Let's start by creating the ~init.el~ file in your
 #+end_src
 
 Emacs customization is largely a matter of setting the values of certain
-variables. The Emacs customization system will store these in the file
-known as the ~custom-file~ which defaults to your initialization file, in
-this case called ~init.el~. We'd rather keep that separate from what we are
-doing in the ~init.el~ file as that code is auto-generated by Emacs. In a
-sense, it is a duplication of the work we will be doing as the values we
-set programmatically will also be stored in this file and loaded by the
-code above.
+variables. The Emacs customization system will store these in the file known as
+the ~custom-file~ which defaults to your initialization file, in this case called
+=init.el=. We'd rather keep that separate from what we are doing in the =init.el=
+file as that code is auto-generated by Emacs. In a sense, it is a duplication of
+the work we will be doing as the values we set programmatically will also be
+stored in this file and loaded by the code above.
 
 For more information on the ~custom-file~ see [[info:emacs#Saving Customizations][Saving Customizations]],
 or on the web: [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Saving-Customizations.html][Saving Customizations]].
 
 Right below the ~custom-file~ setup, add the following line (which assumes
-the ~crafted-emacs-home~ is the ~crafted-emacs~ directory found in your
+the ~crafted-emacs-home~ is the =crafted-emacs= directory found in your
 home folder):
 
 #+begin_src emacs-lisp
@@ -145,41 +141,39 @@ home folder):
 #+end_src
 
 In a rough outline, the ~crafted-init-config~:
-- sets up the load-path, so code from ~modules~ and ~custom-modules~ can
+- sets up the load-path, so code from =modules= and =custom-modules= can
   be loaded with ~require~
 - sets up the ~info~ system to make this documentation accessible from
   within Emacs' info buffer
 - ensures all customizations and packages are saved to the ~custom-file~
 
-These lines define the top of our ~init.el~, everything else will be put
+These lines define the top of our =init.el=, everything else will be put
 below.
 
 * Crafted Emacs Modules
 
-Now that you have bootstrapped @@texinfo:@emph{Crafted Emacs}@@,
+Now that you have bootstrapped Crafted Emacs,
 you can start configuring Emacs using Crafted Emacs Modules.
 
 ** Installing packages
 
-The standard approach to finding and installing packages is to use
-the command ~M-x list-packages RET~, which will bring up a
-user interface to search for packages, review the package details,
-install, update or remove package.
-For more information: [[info:emacs#Packages][Packages]] or on the web: [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Packages.html][Packages]].
+The standard approach to finding and installing packages is to use the command
+=M-x= ~list-packages RET~, which will bring up a user interface to search for
+packages, review the package details, install, update or remove package. For
+more information: [[info:emacs#Packages][Packages]] or on the web: [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Packages.html][Packages]].
 
-@@texinfo:@emph{Crafted Emacs}@@ uses the selection facilities
-for batch-installation of packages. This means all packages are added
-to a list (namely ~package-selected-packages~) and installed at once.
+Crafted Emacs uses the selection facilities for batch-installation of packages.
+This means all packages are added to a list (namely ~package-selected-packages~)
+and installed at once.
 
 #+begin_src emacs-lisp
 ;; Example: Adding "vertico" to the package-selected-packages list (init.el)
 (add-to-list 'package-selected-packages 'vertico)
 #+end_src
 
-Additionally, @@texinfo:@emph{Crafted Emacs}@@ provides a few
-modules which are bundled together packages for installation.
-Each of these modules simply adds one or more package names to the
-~package-selected-packages~ list, for example:
+Additionally, Crafted Emacs provides a few modules which are bundled together
+packages for installation. Each of these modules simply adds one or more package
+names to the ~package-selected-packages~ list, for example:
 
 #+begin_src emacs-lisp
   ;; snippet of crafted-completion-packages.el:
@@ -190,9 +184,9 @@ Each of these modules simply adds one or more package names to the
   (add-to-list 'package-selected-packages 'corfu)
 #+end_src
 
-After all packages are selected,
-they are installed at once with ~package-install-selected-packages~.
-Adding packages after this line will not install them.
+After all packages are selected, they are installed at once with
+~package-install-selected-packages~. Adding packages after this line will not
+install them.
 
 #+begin_src emacs-lisp
 ;; adding the `:noconfirm' flag will cause all the packages listed in
@@ -203,7 +197,7 @@ Adding packages after this line will not install them.
 
 ** Using Crafted Emacs Modules
 
-There are two types of modules provided by @@texinfo:@emph{Crafted Emacs}@@.
+There are two types of modules provided by Crafted Emacs.
 
 1. Package modules (bundle together multiple packages for installation)
 2. Configuration modules (configuration for multiple packages)
@@ -212,14 +206,11 @@ The module definitions can be found in =crafted-emacs-home/modules/=.
 
 *** Package definitions: crafted-*-packages
 
-As explained earlier in the guide, you can add packages manually
-using ~add-to-list~.
-Additionally, @@texinfo:@emph{Crafted Emacs}@@ provides a few
-modules which are bundled together packages for installation.
-Each of these modules simply adds one or more package names to the
-~package-selected-packages~ list.
-The bundles of packages are split up by logical categories
-(ui, completion, writing, ...).
+As explained earlier in the guide, you can add packages manually using
+~add-to-list~. Additionally, Crafted Emacs provides a few modules which are
+bundled together packages for installation. Each of these modules simply adds
+one or more package names to the ~package-selected-packages~ list. The bundles of
+packages are split up by logical categories (ui, completion, writing, ...).
 
 To load one of these bundles, use:
 
@@ -239,9 +230,9 @@ To list all the available package bundle available, you can run:
 ls ./modules/*-packages.el
 #+end_src
 
-*** Configuration: crafted-*-config
+*** Configuration: ~crafted-*-config~
 
-The configuration code provided by @@texinfo:@emph{Crafted Emacs}@@
+The configuration code provided by Crafted Emacs
 is to be loaded after installing all the packages.
 
 #+begin_src emacs-lisp
@@ -252,9 +243,8 @@ is to be loaded after installing all the packages.
 (require 'crafted-completion-config)
 #+end_src
 
-It should be noted that the package definitions are not required
-to use the configuration.
-You can manually add a subset of packages, the configuration code
+It should be noted that the package definitions are not required to use the
+configuration. You can manually add a subset of packages, the configuration code
 will only apply the configuration for those packages:
 
 #+begin_src emacs-lisp
@@ -280,14 +270,14 @@ ls ./modules/*-config.el
 
 The example assumes you have cloned crafted-emacs to your home directory.
 
-Example @@texinfo:@code{early-init.el}@@:
+Example =early-init.el=:
 
 #+begin_src emacs-lisp
   ;; Set up package archives
   (load "~/crafted-emacs/modules/crafted-early-init-config")
 #+end_src
 
-Example @@texinfo:@code{init.el}@@:
+Example =init.el=:
 
 #+begin_src emacs-lisp
   ;; Set up custom.el file
@@ -313,13 +303,13 @@ Example @@texinfo:@code{init.el}@@:
   (require 'crafted-completion-config)
 #+end_src
 
-See the ~examples~ folder in the git-repo for more examples.
+See the =examples= folder in the git-repo for more examples.
 
 * To save or not to save customizations
 
 As described previously, by default Crafted Emacs will save both the list
-=package-selected-packages= and all customizations to your customization file
-(e.g. ~custom.el~).
+~package-selected-packages~ and all customizations to your customization file
+(e.g. =custom.el=).
 
 You can customize that, too. To change that behaviour, add one or both of the
 following lines to your config:
@@ -329,15 +319,15 @@ following lines to your config:
   (customize-set-variable 'crafted-init-auto-save-selected-packages nil)
 #+end_src
 
-Whether or not to save these settings to ~custom.el~ is ultimately a matter of
+Whether or not to save these settings to =custom.el= is ultimately a matter of
 personal preference. You probably won't notice a difference either way.
 
 In the case of the customizations, we call the function
-=customize-save-customized= under the hood, which is originally intended for users
+~customize-save-customized~ under the hood, which is originally intended for users
 who use the Customization UI to try out a bunch of settings and then decide to
 conserve the state of their Emacs session. If you are such a user, you still
-have to run =customize-save-customized= manually, because the settings above save
-the customizations during /startup/ (via the =after-init-hook=). So it saves the
+have to run ~customize-save-customized~ manually, because the settings above save
+the customizations during /startup/ (via the ~after-init-hook~). So it saves the
 customizations that are already present in your configuration.
 
 So why did we turn that on, if it's redundant? It has to do with another use of
@@ -350,11 +340,11 @@ Crafted Emacs module. So to leave Crafted Emacs behind, you don't need to go
 through the code of the modules and consider all the ifs and whens we had to
 consider for different users. You can see the resulting settings /for you/. It's
 all there in you customization file. Combine it with the stuff you added
-yourself and you have the basis for your new ~init.el~.
+yourself and you have the basis for your new =init.el=.
 
 True, to achieve that, these customizations don't need to be saved every
 session. When you decide to leave Crafted Emacs behind, you can just run
-=customize-save-customized= and =package--save-selected-packages= manually and
+~customize-save-customized~ and ~package--save-selected-packages~ manually and
 achieve the same result. But we want to make it as easy as possible for users to
 leave Crafted Emacs behind. And as it doesn't have any noticeable effect on
 startup time, we just do it automatically every session and even spare you the
@@ -364,14 +354,14 @@ Still, if you prefer not to save customizations and/or the list of selected
 packages during each startup, you can turn that behaviour off as described
 above.
 
-Please note: These variables only affect whether /Crafted Emacs/ will or won't
-automatically store anything set by customize-set-variable, but that doesn't
+Please note: These variables only affect whether Crafted Emacs will or won't
+automatically store anything set by ~customize-set-variable~, but that doesn't
 hinder other processes in Emacs to do so.
 
 * Where to go from here
 
-Congratulations,
-crafted-emacs is now set up for you to start your configuration.
+Congratulations, Crafted Emacs is now set up for you to start your
+configuration.
 
 Here are some pointers to get you started:
 - For more details on Crafted Emacs Modules: [[info:crafted-emacs.info#Modules][Modules]]

--- a/docs/getting-started-guide.org
+++ b/docs/getting-started-guide.org
@@ -158,7 +158,7 @@ you can start configuring Emacs using Crafted Emacs Modules.
 ** Installing packages
 
 The standard approach to finding and installing packages is to use the command
-=M-x= ~list-packages RET~, which will bring up a user interface to search for
+=M-x list-packages=, which will bring up a user interface to search for
 packages, review the package details, install, update or remove package. For
 more information: [[info:emacs#Packages][Packages]] or on the web: [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Packages.html][Packages]].
 


### PR DESCRIPTION
use `=` for:

- file paths, e.g. `=init.el=`
- buffer names, e.g. `=*Messages*=`
- values (except numbers, which stay plain), e.g. `=nil=`
- keystrokes or keybindings, e.g. `=C-n=`
- text (to be) entered into the minibuffer (unless it is a complete command name), e.g. `=buf=`
- info nodes, e.g. `=(emacs)Just Spaces=`

`~` for:

- module names, e.g. `~crafted-defaults-config~`
- variable names, incl. external ones, e.g. `~load-prefer-newer~`, `~$PATH~`
- function names, e.g. `~car~`
- command names, incl. external ones, e.g. `~find-file~`, `~make~`
- package names, incl. ones that are shaped like a file name, e.g. `~denote~`, `~package.el~`

This resolves #311 #359 