### PR TITLE
Move creation of startup-screen to `crafted-startup-config`

### DIFF
--- a/examples/init-example.el
+++ b/examples/init-example.el
@@ -41,10 +41,6 @@
 ;; for you and add them here.
 (require 'crafted-defaults-config)
 (require 'crafted-startup-config)
-(unless crafted-startup-inhibit-splash
-  ;; Setting the initial-buffer-choice to the function to show the
-  ;; Crafted Emacs startup screen when Emacs is started.
-  (setq initial-buffer-choice #'crafted-startup-screen))
 
 ;;; Optional configuration
 

--- a/modules/crafted-startup-config.el
+++ b/modules/crafted-startup-config.el
@@ -196,5 +196,10 @@ starts.  See the variable documenation for
                 (fit-window-to-buffer window))))
       (switch-to-buffer splash-buffer))))
 
+(unless crafted-startup-inhibit-splash
+  ;; Setting the initial-buffer-choice to the function to show the
+  ;; Crafted Emacs startup screen when Emacs is started.
+  (setq initial-buffer-choice #'crafted-startup-screen))
+
 (provide 'crafted-startup-config)
 ;;; crafted-startup-config.el ends here


### PR DESCRIPTION
I noticed that without this change, crafted-startup-config won't automatically create the splash screen, unless the user explicitely sets `initial-buffer-choice` to `#'crafted-startup-screen`. Which makes the variable `crafted-startup-inhibit-splash` redundant.

We only actually use it in the example init.el file.

With moving it to `crafted-startup-config`, it now behaves as documented. When the module is required, the splash screen is automatically shown, unless the user sets `crafted-startup-inhibit-splash` to non-nil.