### PR TITLE
fix: version check for tree-sitter configuration

### DIFF
--- a/modules/crafted-ide-config.el
+++ b/modules/crafted-ide-config.el
@@ -90,8 +90,8 @@ For Emacs 29 or later:
 Requires Emacs to be built using \"--with-tree-sitter\".
 All language grammars are auto-installed unless they are a member of OPT-OUT."
   (if (version< emacs-version "29")
-      (crafted-ide--configure-tree-sitter opt-out)
-    (crafted-ide--configure-tree-sitter-pre-29)))
+      (crafted-ide--configure-tree-sitter-pre-29)
+    (crafted-ide--configure-tree-sitter opt-out)))
 
 ;; turn on aggressive indent if it is available, otherwise use
 ;; electric indent.


### PR DESCRIPTION
`crafted-ide--configure-tree-sitter-pre-29` should be called for versions < 29