### PR TITLE
Configure auto-mode-alist for tree-sitter modes

### DIFF
--- a/modules/crafted-ide-config.el
+++ b/modules/crafted-ide-config.el
@@ -75,11 +75,56 @@ OPT-OUT is a list of symbols of language grammars to opt out before auto-install
       ;; prefer tree-sitter modes
       (global-treesit-auto-mode)
       ;; install all the tree-sitter grammars
-      (treesit-auto-install-all))
+      (treesit-auto-install-all)
+      ;; configure `auto-mode-alist' for tree-sitter modes relying on
+      ;; `fundamental-mode'
+      (crafted-ide--configure-tree-sitter-modes))
     (when (locate-library "combobulate")
       ;; perhaps too gross of an application, but the *-ts-modes
       ;; eventually derive from this mode.
       (add-hook 'prog-mode-hook #'combobulate-mode))))
+
+(defvar crafted-ide-tree-sitter-auto-mode-alist
+  '((typescript . ("\\.ts\\'" . typescript-ts-mode))
+    (tsx . ("\\.tsx\\'" . tsx-ts-mode))
+    (rust . ("\\.rs\\'" . rust-ts-mode))
+    (go . ("\\.go\\'" . go-ts-mode))
+    (gomod . ("go.mod" . go-mod-ts-mode))
+    (yaml . ("\\.ya?ml\\'" . yaml-ts-mode))
+    (julia . ("\\.jl\\'" . julia-ts-mode))
+    (lua . ("\\.lua\\'" . lua-ts-mode))
+    (markdown . ("\\.md\\'" . markdown-ts-mode))
+    (dockerfile . ("Dockerfile\\'" . dockerfile-mode)))
+  "Map of tree-sitter languages to `auto-mode-alist' entries.")
+
+(defun crafted-ide--configure-tree-sitter-modes ()
+  "Add tree-sitter modes to `auto-mode-alist'.
+
+`global-treesit-auto-mode' only remaps major modes to their
+tree-sitter equivalent if a prerequisite major mode is active.
+Oftentimes that major mode requires installing an additional
+package, since many languages are only supported by
+`fundamental-mode' out of the box.  This function registers
+`auto-mode-alist' entries for all tree-sitter parsers that are
+installed but lack the required remap mode."
+  (let ((recipes-lacking-modes
+         (seq-filter
+          (lambda (recipe)
+            (and
+             (treesit-ready-p (treesit-auto-recipe-lang recipe) t)
+             (not (crafted-ide--tree-sitter-recipe-bound-p recipe))))
+          treesit-auto-recipe-list)))
+    (dolist (recipe recipes-lacking-modes)
+      (when-let ((automode (alist-get (treesit-auto-recipe-lang recipe)
+                                      crafted-ide-tree-sitter-auto-mode-alist)))
+        (add-to-list 'auto-mode-alist automode)))))
+
+(defun crafted-ide--tree-sitter-recipe-bound-p (recipe)
+  "Return t if RECIPE remap function definition is not void."
+  (when-let ((remap (treesit-auto-recipe-remap recipe)))
+    (if (listp remap)
+        (seq-some (lambda (mode) (fboundp mode)) remap)
+      (fboundp remap))))
 
 (defun crafted-ide-configure-tree-sitter (&optional opt-out)
   "Configure tree-sitter.

--- a/modules/crafted-ide-config.el
+++ b/modules/crafted-ide-config.el
@@ -94,7 +94,7 @@ OPT-OUT is a list of symbols of language grammars to opt out before auto-install
     (julia . ("\\.jl\\'" . julia-ts-mode))
     (lua . ("\\.lua\\'" . lua-ts-mode))
     (markdown . ("\\.md\\'" . markdown-ts-mode))
-    (dockerfile . ("Dockerfile\\'" . dockerfile-mode)))
+    (dockerfile . ("Dockerfile\\'" . dockerfile-ts-mode)))
   "Map of tree-sitter languages to `auto-mode-alist' entries.")
 
 (defun crafted-ide--configure-tree-sitter-modes ()


### PR DESCRIPTION
Add `auto-mode-alist` entries for many tree-sitter languages that have parsers but may lack the remap mode required by treesit-auto.

This is a bit of an experimental PR, but it solves a problem I ran into when setting up `crafted-ide`. I was surprised to learn that after installing every tree-sitter parser and using the `crafted-ide-config` functions for setting up tree-sitter, the `typescript-ts-mode` would not automatically activate when visiting `.ts` files. After some investigation, I found that in the `treesit-auto` [recipe definition](https://github.com/renzmann/treesit-auto/blob/main/treesit-auto.el#L243-L249) there's a `remap` field that corresponds to a specific major mode that `global-treesit-auto-mode` uses to map to the respective tree-sitter mode. Many of those remap modes are not installed by default.

For example, `typescript-ts-mode` only activates if you first install `typescript-mode` from MELPA. `global-treesit-auto-mode` looks for `typescript-mode` before it activates `typescript-ts-mode`. Otherwise, even with the tree-sitter parsers installed you will be in `fundamental-mode` when visiting `.ts` files.

I'm not 100% sure if this is something you all want for crafted-emacs, but I think it's a nice addition for those using tree-sitter for the first time. Visiting a `.ts` file should "just work" after the typescript parser is installed.