### PR TITLE
docs: Add an evil-escape example

### DIFF
--- a/examples/evil-escape.el
+++ b/examples/evil-escape.el
@@ -1,0 +1,45 @@
+;;; init.el -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; An example Emacs Init file that extends `crafted-evil-packages'
+;; with `evil-escape', allowing alternative key combinations to escape
+;; from Vim's insert-mode.
+
+(setq custom-file (expand-file-name "custom.el" user-emacs-directory))
+(when (and custom-file
+	   (file-exists-p custom-file))
+  (load custom-file nil :nomessage))
+
+(load "~/crafted-emacs/modules/crafted-init-config")
+
+;;; Packages phase
+
+(require 'crafted-evil-packages)
+
+;; Add `evil-escape', the package responsible for binding Escape to an
+;; alternative key combination.
+(add-to-list 'package-selected-packages 'evil-escape)
+
+(package-install-selected-packages :noconfirm)
+
+;;; Configuration phase
+
+(require 'crafted-evil-config)
+
+;; Configure `evil-escape' with the preferred key combination "jj".
+(customize-set-variable 'evil-escape-key-sequence (kbd "jj"))
+
+;; Allow typing "jj" literally without exiting from insert-mode
+;; if the keys are pressed 0.2s apart.
+(customize-set-variable 'evil-escape-delay 0.2)
+
+;; Prevent "jj" from escaping any mode other than insert-mode.
+(defun my/not-insert-state-p ()
+  "Inverse of `evil-insert-state-p`"
+  (not (evil-insert-state-p)))
+
+(customize-set-variable 'evil-escape-inhibit-functions (list #'my/not-insert-state-p))
+
+;; Enable `evil-escape' mode globally.
+(evil-escape-mode)


### PR DESCRIPTION
Add an example for binding alternative key combinations to escape from insert-mode when using crafted-evil.

I was hopeful this example would be useful for other Vim users who prefer rebinding Escape to "jj" or some other key combination.

It also addresses one confusion I had when working through the docs. When I add my own configuration outside of crafted-emacs, is it important that I avoid the use of something like `use-package` and prefer the `package-selected-packages` variable provided by crafted-emacs? For `evil-escape` at least, I ran into a few warnings/errors with my original `use-package` configuration that were resolved by swapping over to the `package-selected-packages` variable. The documentation is great for configuring the different aspects within crafted-emacs, but I was a little unsure how I should configure things outside of that zone.