### PR TITLE
Splash screen updates

### DIFF
--- a/modules/crafted-startup-config.el
+++ b/modules/crafted-startup-config.el
@@ -122,9 +122,6 @@ Each element in the list should be a list of strings or pairs
   (when (file-exists-p project-list-file)
     (project--read-project-list)
     (message "Showing projects on splash screen")
-    (message (format "project count %s" (length project--list)))
-    (dolist (proj (seq-take project--list crafted-startup-project-count))
-      (message (format "%s" (car proj))))
     (fancy-splash-insert
      :face '(variable-pitch font-lock-string-face italic)
      (condition-case project--list
@@ -137,8 +134,7 @@ Each element in the list should be a list of strings or pairs
             (dolist (proj (seq-take project--list crafted-startup-project-count))
               (fancy-splash-insert
                :face 'default
-               (format "%s" (car proj))
-               ;; :link `(,file ,(lambda (_button) (car proj)))
+               :link `(,(car proj) ,(lambda (_button) (project-switch-project (car proj))))
                "\n"))
           "\n")
       (error "\n"))))
@@ -161,6 +157,11 @@ Each element in the list should be a list of strings or pairs
              "\n"))
         "\n")
     (error "\n")))
+
+(defvar crafted-startup-module-list '(crafted-startup-projects crafted-startup-recentf)
+  "List of functions to call to display \"modules\" on the splash
+screen.  Functions are called in the order listed.  See
+`crafted-startup-recentf' as an example.")
 
 (defun crafted-startup-screen (&optional concise)
   "Display fancy startup screen.
@@ -208,7 +209,7 @@ starts.  See the variable documenation for
                 (skip-chars-backward "\n")
                 (delete-region (point) (point-max))
                 (insert "\n"))
-              '(crafted-startup-recentf crafted-startup-projects))
+              crafted-startup-module-list)
         (skip-chars-backward "\n")
         (delete-region (point) (point-max))
         (insert "\n")

--- a/modules/crafted-startup-config.el
+++ b/modules/crafted-startup-config.el
@@ -50,12 +50,14 @@
 Each element in the list should be a list of strings or pairs
 `:face FACE', like `fancy-splash-insert' accepts them.")
 
-(defvar crafted-startup-module-list '(crafted-startup-recentf)
+(defcustom crafted-startup-module-list '(crafted-startup-recentf)
   "List of functions to call to display \"modules\" on the splash
 screen.  Functions are called in the order listed.  See
 `crafted-startup-recentf' as an example.  Current list provided
  by Crafted Emacs is `crafted-startup-diary',
- `crafted-startup-projects', `crafted-startup-recentf'")
+ `crafted-startup-projects', `crafted-startup-recentf'"
+  :type '(repeat function)
+  :group 'crafted-startup)
 
 (defvar crafted-startup-screen-inhibit-startup-screen nil)
 
@@ -145,8 +147,7 @@ screen.  Functions are called in the order listed.  See
               (dolist (entry entries)
                 (fancy-splash-insert
                  :face 'default
-                 entry
-                 "\n"))
+                 (format "%s\n" entry)))
             "\n")
         (error "\n")))))
 
@@ -166,7 +167,6 @@ screen.  Functions are called in the order listed.  See
         (if (not (seq-empty-p project--list))
             (dolist (proj (seq-take project--list crafted-startup-project-count))
               (fancy-splash-insert
-               :face 'default
                :link `(,(car proj) ,(lambda (_button) (project-switch-project (car proj))))
                "\n"))
           "\n")
@@ -185,7 +185,6 @@ screen.  Functions are called in the order listed.  See
       (if (not (seq-empty-p recentf-list))
           (dolist (file (seq-take recentf-list crafted-startup-recentf-count))
             (fancy-splash-insert
-             :face 'default
              :link `(,file ,(lambda (_button) (find-file file)))
              "\n"))
         "\n")

--- a/modules/crafted-startup-config.el
+++ b/modules/crafted-startup-config.el
@@ -50,7 +50,7 @@
 Each element in the list should be a list of strings or pairs
 `:face FACE', like `fancy-splash-insert' accepts them.")
 
-(defvar crafted-startup-module-list '(crafted-startup-diary crafted-startup-recentf crafted-startup-projects)
+(defvar crafted-startup-module-list '(crafted-startup-recentf)
   "List of functions to call to display \"modules\" on the splash
 screen.  Functions are called in the order listed.  See
 `crafted-startup-recentf' as an example.  Current list provided


### PR DESCRIPTION
Some updates to add "modules" like the list of projects (from `project.el`) and today's diary entries to the splash screen.  Need to customize the list `crafted-startup-module-list` to call the functions which put the information on the screen.  Needs to be added to documentation, this PR is for reviewing the code.

