### PR TITLE
Add Bug Report and Package Request Forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yml
@@ -1,0 +1,73 @@
+---
+name: Bug Report
+description: Interactive Form for filing bug reports
+labels: ["bug"]
+body:
+  - type: markdown
+    id: general
+    attributes:
+      value: First, please tell us a little bit about your setup. This helps reproducing the issue.
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      description: What Operating System do you use?
+      options:
+        - Linux/BSD
+        - Windows
+        - Mac
+        - Android
+        - other
+      default: 0
+  - type: input
+    id: os-details
+    attributes:
+      label: Additional Operating System information
+      description: Anything additional about your OS setup? Distribution, Version, ...
+      placeholder: GNU/Guix
+  - type: dropdown
+    id: emacs-version
+    attributes:
+      label: Emacs Version
+      description: What version of Emacs have you encountered this issue? (You can run `M-x emacs-version RET` to find out)
+      options:
+        - 27
+        - 28
+        - 29
+      default: 0
+    validations:
+      required: true
+  - type: checkboxes
+    id: emacs-configuration-info
+    attributes:
+      label: Emacs Configuration Details
+      description: Some more about your Emacs configuration (if you don't know, ignore this section and mention it in the text area below)
+      options:
+        - label: Native Compilation
+        - label: pGTK
+        - label: alternative package manager (use-package, straight.el, ...)
+    validations:
+      required: true
+  - type: textarea
+    id: emacs-user-info
+    attributes:
+      label: Anything else that may be related to the issue you're having?
+      description: Any information you think is important to understanding the issue that we should know (other versions tested, ...).
+  - type: markdown
+    id: general
+    attributes:
+      value: Now, let's get into the details about the issue.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Please describe the bug you encountered. If you can, please provide a step-by-step way to reproduce the bug and a backtrace (using `(toggle-debug-on-error)` to display the backtrace on error) of the issue.
+    validations:
+      required: true
+  - type: textarea
+    id: what-should-have-happened
+    attributes:
+      label: What should have happened?
+      description: Please describe the behaviour you were expecting.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/package_request_form.yml
+++ b/.github/ISSUE_TEMPLATE/package_request_form.yml
@@ -1,0 +1,49 @@
+---
+name: Package Report
+description: Interactive Form for requesting packages added to Crafted Emacs
+title: "[Package Request] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    id: preface
+    attributes:
+      value: Please ensure that the package aligns with the Goals of Crafted Emacs before submitting a package request.
+  - type: input
+    id: package-name
+    attributes:
+      label: Package Name
+      description: Name of the package (potentially also how it's named on certain platforms)
+  - type: dropdown
+    id: package-origin
+    attributes:
+      label: Emacs Lisp Package Archive (ELPA)
+      description: Which package archive can this package be obtained from?
+      options:
+        - GNU ELPA
+        - NonGNU ELPA
+        - MELPA Stable
+        - MELPA
+      default: 0
+  - type: dropdown
+    id: emacs-version
+    attributes:
+      label: Emacs Version
+      description: What minimum version of Emacs is required for this package?
+      options:
+        - less than 27
+        - 27
+        - 28
+        - 29
+      default: 0
+    validations:
+      required: true
+  - type: textarea
+    id: additional-requirements
+    attributes:
+      label: Additional requirements
+      description: Are there additional requirements (C compiler, other programs, ...) to use the package?
+  - type: textarea
+    id: package-info
+    attributes:
+      label: Why should this package be included?
+      description: Please explain what the package brings to Crafted Emacs and how it fits into the current infrastructure.


### PR DESCRIPTION
Adds issue template forms using the new (beta) YAML format (see #46 for discussion).
I'm still working on the feature request form, but this should be good for now.

These need to go in the `master` branch for GitHub to actually use them.

Display when creating new issues:
![forms-creating-view](https://github.com/SystemCrafters/crafted-emacs/assets/62522175/015fb101-26ad-4795-b632-ad196084b8d7)

Bug Report Form:
![bug-report-form](https://github.com/SystemCrafters/crafted-emacs/assets/62522175/85ea6caa-f7b5-47be-9271-6a2748269959)

Package Request Form:
![pkg-request-form](https://github.com/SystemCrafters/crafted-emacs/assets/62522175/3ae91017-d62c-43e6-bfde-cdca33c17679)
