### PR TITLE
[v2] Move centering of Welcome Text from the constant to the function.

### DIFF
--- a/modules/crafted-startup-config.el
+++ b/modules/crafted-startup-config.el
@@ -85,13 +85,12 @@ line or the centering will by off.")
      (make-string (abs (- (/ line-width 2) str-mid)) ? ) ;;fill w/ spaces
      str)))
 
+(defconst crafted-welcome-text
+  "Welcome to Crafted Emacs!"
+  "First text on the splash screen.")
+
 (defconst crafted-startup-text
-  `((:face (crafted-greeting-face)
-           ,(crafted-startup--center-with-face
-             "Welcome to Crafted Emacs!"
-             'crafted-greeting-face)
-           "\n\n"
-           :face variable-pitch
+  `((:face variable-pitch
            :link ("View Crafted Emacs Manual"
                   ,(lambda (_button) (info "crafted-emacs")))
            "\tView the Crafted Emacs manual using Info\n"
@@ -309,8 +308,14 @@ starts.  See the variable documenation for
         (if pure-space-overflow
             (insert pure-space-overflow-message))
         (unless concise
-          (crafted-startup-splash-head))
-        (dolist (text crafted-startup-text)
+          (crafted-startup-splash-head))            ;; display the logo
+        (apply #'fancy-splash-insert                ;; insert welcome text
+               `(:face (crafted-greeting-face)
+                      ,(crafted-startup--center-with-face
+                        crafted-welcome-text
+                        'crafted-greeting-face)))
+        (insert "\n\n")
+        (dolist (text crafted-startup-text)         ;; the rest of the text
           (apply #'fancy-splash-insert text)
           (insert "\n"))
         (with-eval-after-load 'crafted-updates-config


### PR DESCRIPTION
Centering of the image and the text happened at different points in time.
If the user has a setup where `crafted-startup-screen` is called after initial startup, this can mess up the alignment of image and text.
With this, both image and text are centered at the same time, i.e. whenever `crafted-startup-screen` is called.