### PR TITLE
Add package-lint and package-lint-flymake to crafted-lisp

### DIFF
--- a/docs/crafted-emacs.info
+++ b/docs/crafted-emacs.info
@@ -2262,13 +2262,8 @@ development using various Lisp and Scheme variants.
   1. Emacs Lisp
 
      Package lint helps ensure your Emacs Lisp code follows style
-     conventions and best practices.  It's recommended to enable Flymake
-     in your configuration to take full advantage of the Emacs linting
-     tools:
-
-          (add-hook 'emacs-lisp-mode-hook #'package-lint-flymake-setup)
-
-     This activates the following Flymake backends:
+     conventions and best practices.  By default, the following Flymake
+     backends are enabled:
 
         • ‘elisp-flymake-checkdoc’: Documentation verbiage and style
           conventions.
@@ -2277,9 +2272,9 @@ development using various Lisp and Scheme variants.
         • ‘package-lint-flymake’: Package conventions to ensure your
           Emacs library can be installed by other users.
 
-     Alternatively, you may lint the buffer on a per-use basis by
-     invoking the commands: ‘package-lint-current-buffer’, ‘checkdoc’,
-     or ‘byte-compile-file’.
+     You may lint the buffer on a per-use basis by invoking the
+     commands: ‘package-lint-current-buffer’, ‘checkdoc’, or
+     ‘byte-compile-file’.
 
   2. Common Lisp
 
@@ -3459,60 +3454,60 @@ Node: Crafted Emacs Lisp Module83352
 Node: Installation (4)83664
 Node: Description (4)84171
 Ref: Emacs Lisp84771
-Ref: Common Lisp85681
-Ref: Clojure86547
-Ref: Scheme and Racket87183
-Node: Additional packages geiser-*87779
-Node: Crafted Emacs Org Module88823
-Node: Installation (5)89133
-Node: Description (5)89635
-Node: Alternative package org-roam91652
-Node: Crafted Emacs OSX Module93456
-Node: Installation (6)93739
-Node: Description (6)94051
-Node: Crafted Emacs Screencast Module95085
-Node: Installation (7)95387
-Node: Description (7)95924
-Node: Crafted Emacs Speedbar Module96625
-Node: Installation (8)96927
-Node: Description (8)97398
-Node: Crafted Emacs Startup Module99901
-Node: Installation (9)100267
-Node: Description (9)100737
-Node: Logo101034
-Node: Updates102152
-Node: Modules (1)102646
-Node: Turn off splash screen104700
-Node: Crafted Emacs UI Module105216
-Node: Installation (10)105501
-Node: Description (10)106002
-Ref: Icons with all-the-icons106731
-Ref: Line numbers107244
-Node: Crafted Emacs Updates Module108535
-Node: Installation (11)108833
-Node: Description (11)109305
-Ref: Usage and Customization109883
-Ref: On Startup110034
-Ref: Regularly110749
-Ref: Manually111682
-Node: Crafted Emacs Workspaces Module112281
-Node: Installation (12)112590
-Node: Description (12)113131
-Node: Crafted Emacs Writing Module114682
-Node: Installation (13)114948
-Node: Description (13)115474
-Ref: Whitespace Mode116001
-Ref: Function crafted-writing-configure-whitespace116467
-Ref: Signature116535
-Ref: Parameters116702
-Ref: Examples117619
-Ref: Optional Package PDF-Tools118728
-Ref: Part 1 Installing the Emacs package pdf-tools119074
-Ref: Part 2 Installing the epdfinfo-server119492
-Ref: Configuration120214
-Node: Troubleshooting120696
-Node: A package (suddenly?) fails to work120930
-Node: MIT License124702
+Ref: Common Lisp85483
+Ref: Clojure86349
+Ref: Scheme and Racket86985
+Node: Additional packages geiser-*87581
+Node: Crafted Emacs Org Module88625
+Node: Installation (5)88935
+Node: Description (5)89437
+Node: Alternative package org-roam91454
+Node: Crafted Emacs OSX Module93258
+Node: Installation (6)93541
+Node: Description (6)93853
+Node: Crafted Emacs Screencast Module94887
+Node: Installation (7)95189
+Node: Description (7)95726
+Node: Crafted Emacs Speedbar Module96427
+Node: Installation (8)96729
+Node: Description (8)97200
+Node: Crafted Emacs Startup Module99703
+Node: Installation (9)100069
+Node: Description (9)100539
+Node: Logo100836
+Node: Updates101954
+Node: Modules (1)102448
+Node: Turn off splash screen104502
+Node: Crafted Emacs UI Module105018
+Node: Installation (10)105303
+Node: Description (10)105804
+Ref: Icons with all-the-icons106533
+Ref: Line numbers107046
+Node: Crafted Emacs Updates Module108337
+Node: Installation (11)108635
+Node: Description (11)109107
+Ref: Usage and Customization109685
+Ref: On Startup109836
+Ref: Regularly110551
+Ref: Manually111484
+Node: Crafted Emacs Workspaces Module112083
+Node: Installation (12)112392
+Node: Description (12)112933
+Node: Crafted Emacs Writing Module114484
+Node: Installation (13)114750
+Node: Description (13)115276
+Ref: Whitespace Mode115803
+Ref: Function crafted-writing-configure-whitespace116269
+Ref: Signature116337
+Ref: Parameters116504
+Ref: Examples117421
+Ref: Optional Package PDF-Tools118530
+Ref: Part 1 Installing the Emacs package pdf-tools118876
+Ref: Part 2 Installing the epdfinfo-server119294
+Ref: Configuration120016
+Node: Troubleshooting120498
+Node: A package (suddenly?) fails to work120732
+Node: MIT License124504
 
 End Tag Table
 

--- a/docs/crafted-emacs.info
+++ b/docs/crafted-emacs.info
@@ -2259,7 +2259,29 @@ development using various Lisp and Scheme variants.
      or moving code around.  ‘aggressive-indent-mode’ is added to
      ‘lisp-mode-hook’, ‘scheme-mode-hook’ and ‘clojure-mode-hook’.
 
-  1. Common Lisp
+  1. Emacs Lisp
+
+     Package lint helps ensure your Emacs Lisp code follows style
+     conventions and best practices.  It's recommended to enable Flymake
+     in your configuration to take full advantage of the Emacs linting
+     tools:
+
+          (add-hook 'emacs-lisp-mode-hook #'package-lint-flymake-setup)
+
+     This activates the following Flymake backends:
+
+        • ‘elisp-flymake-checkdoc’: Documentation verbiage and style
+          conventions.
+        • ‘elisp-flymake-byte-compile’: Errors and warnings surfaced
+          when byte compiling via ‘byte-compile-file’.
+        • ‘package-lint-flymake’: Package conventions to ensure your
+          Emacs library can be installed by other users.
+
+     Alternatively, you may lint the buffer on a per-use basis by
+     invoking the commands: ‘package-lint-current-buffer’, ‘checkdoc’,
+     or ‘byte-compile-file’.
+
+  2. Common Lisp
 
      The configuration for Common Lisp features Sylvester the cat’s
      Common Lisp IDE for Emacs (‘sly’).  The ‘sly-editing-mode’ is added
@@ -2282,7 +2304,7 @@ development using various Lisp and Scheme variants.
           ;; Using roswell
           (customize-set-variable 'inferior-lisp-program "/usr/bin/ros run")
 
-  2. Clojure
+  3. Clojure
 
         • Package: ‘cider’
 
@@ -2305,7 +2327,7 @@ development using various Lisp and Scheme variants.
 
           Flycheck integration for Clojure linters.
 
-  3. Scheme and Racket
+  4. Scheme and Racket
 
      The Scheme and Racket configuration is entirely based around
      ‘geiser’.
@@ -3436,60 +3458,61 @@ Ref: Combobulate82545
 Node: Crafted Emacs Lisp Module83352
 Node: Installation (4)83664
 Node: Description (4)84171
-Ref: Common Lisp84771
-Ref: Clojure85637
-Ref: Scheme and Racket86273
-Node: Additional packages geiser-*86869
-Node: Crafted Emacs Org Module87913
-Node: Installation (5)88223
-Node: Description (5)88725
-Node: Alternative package org-roam90742
-Node: Crafted Emacs OSX Module92546
-Node: Installation (6)92829
-Node: Description (6)93141
-Node: Crafted Emacs Screencast Module94175
-Node: Installation (7)94477
-Node: Description (7)95014
-Node: Crafted Emacs Speedbar Module95715
-Node: Installation (8)96017
-Node: Description (8)96488
-Node: Crafted Emacs Startup Module98991
-Node: Installation (9)99357
-Node: Description (9)99827
-Node: Logo100124
-Node: Updates101242
-Node: Modules (1)101736
-Node: Turn off splash screen103790
-Node: Crafted Emacs UI Module104306
-Node: Installation (10)104591
-Node: Description (10)105092
-Ref: Icons with all-the-icons105821
-Ref: Line numbers106334
-Node: Crafted Emacs Updates Module107625
-Node: Installation (11)107923
-Node: Description (11)108395
-Ref: Usage and Customization108973
-Ref: On Startup109124
-Ref: Regularly109839
-Ref: Manually110772
-Node: Crafted Emacs Workspaces Module111371
-Node: Installation (12)111680
-Node: Description (12)112221
-Node: Crafted Emacs Writing Module113772
-Node: Installation (13)114038
-Node: Description (13)114564
-Ref: Whitespace Mode115091
-Ref: Function crafted-writing-configure-whitespace115557
-Ref: Signature115625
-Ref: Parameters115792
-Ref: Examples116709
-Ref: Optional Package PDF-Tools117818
-Ref: Part 1 Installing the Emacs package pdf-tools118164
-Ref: Part 2 Installing the epdfinfo-server118582
-Ref: Configuration119304
-Node: Troubleshooting119786
-Node: A package (suddenly?) fails to work120020
-Node: MIT License123792
+Ref: Emacs Lisp84771
+Ref: Common Lisp85681
+Ref: Clojure86547
+Ref: Scheme and Racket87183
+Node: Additional packages geiser-*87779
+Node: Crafted Emacs Org Module88823
+Node: Installation (5)89133
+Node: Description (5)89635
+Node: Alternative package org-roam91652
+Node: Crafted Emacs OSX Module93456
+Node: Installation (6)93739
+Node: Description (6)94051
+Node: Crafted Emacs Screencast Module95085
+Node: Installation (7)95387
+Node: Description (7)95924
+Node: Crafted Emacs Speedbar Module96625
+Node: Installation (8)96927
+Node: Description (8)97398
+Node: Crafted Emacs Startup Module99901
+Node: Installation (9)100267
+Node: Description (9)100737
+Node: Logo101034
+Node: Updates102152
+Node: Modules (1)102646
+Node: Turn off splash screen104700
+Node: Crafted Emacs UI Module105216
+Node: Installation (10)105501
+Node: Description (10)106002
+Ref: Icons with all-the-icons106731
+Ref: Line numbers107244
+Node: Crafted Emacs Updates Module108535
+Node: Installation (11)108833
+Node: Description (11)109305
+Ref: Usage and Customization109883
+Ref: On Startup110034
+Ref: Regularly110749
+Ref: Manually111682
+Node: Crafted Emacs Workspaces Module112281
+Node: Installation (12)112590
+Node: Description (12)113131
+Node: Crafted Emacs Writing Module114682
+Node: Installation (13)114948
+Node: Description (13)115474
+Ref: Whitespace Mode116001
+Ref: Function crafted-writing-configure-whitespace116467
+Ref: Signature116535
+Ref: Parameters116702
+Ref: Examples117619
+Ref: Optional Package PDF-Tools118728
+Ref: Part 1 Installing the Emacs package pdf-tools119074
+Ref: Part 2 Installing the epdfinfo-server119492
+Ref: Configuration120214
+Node: Troubleshooting120696
+Node: A package (suddenly?) fails to work120930
+Node: MIT License124702
 
 End Tag Table
 

--- a/docs/crafted-lisp.org
+++ b/docs/crafted-lisp.org
@@ -29,14 +29,7 @@ using various Lisp and Scheme variants.
 *** Emacs Lisp
 
 Package lint helps ensure your Emacs Lisp code follows style conventions and
-best practices. It's recommended to enable Flymake in your configuration to take
-full advantage of the Emacs linting tools:
-
-#+begin_src emacs-lisp
-(add-hook 'emacs-lisp-mode-hook #'package-lint-flymake-setup)
-#+end_src
-
-This activates the following Flymake backends:
+best practices. By default, the following Flymake backends are enabled:
 
 - ~elisp-flymake-checkdoc~: Documentation verbiage and style conventions.
 - ~elisp-flymake-byte-compile~: Errors and warnings surfaced when byte compiling
@@ -44,8 +37,8 @@ This activates the following Flymake backends:
 - ~package-lint-flymake~: Package conventions to ensure your Emacs library can be
   installed by other users.
 
-Alternatively, you may lint the buffer on a per-use basis by invoking the
-commands: ~package-lint-current-buffer~, ~checkdoc~, or ~byte-compile-file~.
+You may lint the buffer on a per-use basis by invoking the commands:
+~package-lint-current-buffer~, ~checkdoc~, or ~byte-compile-file~.
 
 *** Common Lisp
 

--- a/docs/crafted-lisp.org
+++ b/docs/crafted-lisp.org
@@ -26,6 +26,27 @@ using various Lisp and Scheme variants.
   code around. ~aggressive-indent-mode~ is added to ~lisp-mode-hook~,
   ~scheme-mode-hook~ and ~clojure-mode-hook~.
 
+*** Emacs Lisp
+
+Package lint helps ensure your Emacs Lisp code follows style conventions and
+best practices. It's recommended to enable Flymake in your configuration to take
+full advantage of the Emacs linting tools:
+
+#+begin_src emacs-lisp
+(add-hook 'emacs-lisp-mode-hook #'package-lint-flymake-setup)
+#+end_src
+
+This activates the following Flymake backends:
+
+- ~elisp-flymake-checkdoc~: Documentation verbiage and style conventions.
+- ~elisp-flymake-byte-compile~: Errors and warnings surfaced when byte compiling
+  via ~byte-compile-file~.
+- ~package-lint-flymake~: Package conventions to ensure your Emacs library can be
+  installed by other users.
+
+Alternatively, you may lint the buffer on a per-use basis by invoking the
+commands: ~package-lint-current-buffer~, ~checkdoc~, or ~byte-compile-file~.
+
 *** Common Lisp
 
   The configuration for Common Lisp features Sylvester the cat’s Common Lisp IDE

--- a/modules/crafted-lisp-config.el
+++ b/modules/crafted-lisp-config.el
@@ -44,6 +44,11 @@
   (add-hook 'clojure-mode-hook #'aggressive-indent-mode)
   (add-hook 'scheme-mode-hook #'aggressive-indent-mode))
 
+;;; Emacs Lisp
+
+(when (locate-library "package-lint-flymake")
+  (add-hook 'emacs-lisp-mode-hook #'package-lint-flymake-setup))
+
 
 ;;; Common Lisp
 

--- a/modules/crafted-lisp-packages.el
+++ b/modules/crafted-lisp-packages.el
@@ -12,12 +12,13 @@
 ;;; Code:
 
 ;; Indentation
-
 (add-to-list 'package-selected-packages 'aggressive-indent)
 
+;; Emacs Lisp
+(add-to-list 'package-selected-packages 'package-lint)
+(add-to-list 'package-selected-packages 'package-lint-flymake)
 
 ;; Common Lisp
-
 (add-to-list 'package-selected-packages 'sly)
 (add-to-list 'package-selected-packages 'sly-asdf)
 (add-to-list 'package-selected-packages 'sly-quicklisp)


### PR DESCRIPTION
Following the discussion https://github.com/SystemCrafters/crafted-emacs/discussions/399#discussioncomment-7835270, this closes the crafted-contrib module (https://github.com/SystemCrafters/crafted-emacs/pull/401) in favor of adding package-lint to crafted-lisp.