### PR TITLE
Fix error passing nil to load

### DIFF
--- a/modules/crafted-init-config.el
+++ b/modules/crafted-init-config.el
@@ -156,7 +156,7 @@ bug above.  If the user never set a value for `custom-file' then
 we can't reload the file."
   (customize-save-customized)
   ;; only load the `custom-file' if it is not `nil'. 
-  (unless custom-file
+  (when custom-file
     (load custom-file :noerror)))
 
 ;; Save all customizations to `custom-file', unless the user opted out.


### PR DESCRIPTION
To avoid passing "nil" to the load function, use when instead of unless.

This change fixes the error for me, so I hope it is correct!