### PR TITLE
Update docs for tree-sitter and breadcrumbs

### DIFF
--- a/docs/crafted-emacs.info
+++ b/docs/crafted-emacs.info
@@ -2313,7 +2313,7 @@ environment (IDE).
 
           Instead, you can pass a list of languages to
           ‘crafted-ide-configure-tree-sitter’, then it will only install
-          those languages.  This can be also be useful if if a certain
+          those languages.  This can be also be useful if a certain
           language grammar doesn't successfully build on your setup, as
           you would otherwise be re-prompted to install new grammars on
           every Emacs startup.
@@ -3083,12 +3083,12 @@ while leaving them turned off for others.
 
   3. Breadcrumb
 
-     The breadcrumb package uses information from ‘imenu.el’ and
-     ‘project.el’ to display helpful to provide orientation within a
-     file and/or project.
+     The breadcrumb package displays helpful information from ‘imenu.el’
+     and ‘project.el’ to provide orientation within a file and/or
+     project.
 
      By default, the global mode of the breadcrumb package is activated:
-     ‘breadcrumb-mode’.  The breadcrumbs ar displayed at the top of the
+     ‘breadcrumb-mode’.  The breadcrumbs are displayed at the top of the
      window.
 
      That behaviour can be tweaked in various ways, see the package's
@@ -3606,66 +3606,66 @@ Ref: Automatically start Eglot when visiting language buffers85280
 Ref: Tree-Sitter85917
 Ref: Configuring Tree-Sitter (Emacs 28 or earlier)86250
 Ref: Configuring Tree-Sitter (Emacs 29 or later)86682
-Ref: Combobulate87716
-Node: Crafted Emacs Lisp Module88523
-Node: Installation (4)88835
-Node: Description (4)89342
-Ref: Emacs Lisp89942
-Ref: Common Lisp90654
-Ref: Clojure91520
-Ref: Scheme and Racket92156
-Node: Additional packages geiser-*92752
-Node: Crafted Emacs Org Module93796
-Node: Installation (5)94106
-Node: Description (5)94608
-Node: Alternative package org-roam96625
-Node: Crafted Emacs OSX Module98429
-Node: Installation (6)98712
-Node: Description (6)99024
-Node: Crafted Emacs Screencast Module100058
-Node: Installation (7)100360
-Node: Description (7)100897
-Node: Crafted Emacs Speedbar Module101598
-Node: Installation (8)101900
-Node: Description (8)102371
-Node: Crafted Emacs Startup Module104874
-Node: Installation (9)105240
-Node: Description (9)105710
-Node: Logo106007
-Node: Updates107125
-Node: Modules (1)107619
-Node: Turn off splash screen109673
-Node: Crafted Emacs UI Module110189
-Node: Installation (10)110474
-Node: Description (10)110975
-Ref: Icons with all-the-icons111704
-Ref: Line numbers112217
-Ref: Breadcrumb113513
-Node: Crafted Emacs Updates Module114260
-Node: Installation (11)114558
-Node: Description (11)115030
-Ref: Usage and Customization115608
-Ref: On Startup115759
-Ref: Regularly116474
-Ref: Manually117407
-Node: Crafted Emacs Workspaces Module118006
-Node: Installation (12)118315
-Node: Description (12)118856
-Node: Crafted Emacs Writing Module120407
-Node: Installation (13)120673
-Node: Description (13)121199
-Ref: Whitespace Mode121726
-Ref: Function crafted-writing-configure-whitespace122192
-Ref: Signature122260
-Ref: Parameters122427
-Ref: Examples123344
-Ref: Optional Package PDF-Tools124453
-Ref: Part 1 Installing the Emacs package pdf-tools124799
-Ref: Part 2 Installing the epdfinfo-server125217
-Ref: Configuration125939
-Node: Troubleshooting126421
-Node: A package (suddenly?) fails to work126655
-Node: MIT License130427
+Ref: Combobulate87713
+Node: Crafted Emacs Lisp Module88520
+Node: Installation (4)88832
+Node: Description (4)89339
+Ref: Emacs Lisp89939
+Ref: Common Lisp90651
+Ref: Clojure91517
+Ref: Scheme and Racket92153
+Node: Additional packages geiser-*92749
+Node: Crafted Emacs Org Module93793
+Node: Installation (5)94103
+Node: Description (5)94605
+Node: Alternative package org-roam96622
+Node: Crafted Emacs OSX Module98426
+Node: Installation (6)98709
+Node: Description (6)99021
+Node: Crafted Emacs Screencast Module100055
+Node: Installation (7)100357
+Node: Description (7)100894
+Node: Crafted Emacs Speedbar Module101595
+Node: Installation (8)101897
+Node: Description (8)102368
+Node: Crafted Emacs Startup Module104871
+Node: Installation (9)105237
+Node: Description (9)105707
+Node: Logo106004
+Node: Updates107122
+Node: Modules (1)107616
+Node: Turn off splash screen109670
+Node: Crafted Emacs UI Module110186
+Node: Installation (10)110471
+Node: Description (10)110972
+Ref: Icons with all-the-icons111701
+Ref: Line numbers112214
+Ref: Breadcrumb113510
+Node: Crafted Emacs Updates Module114251
+Node: Installation (11)114549
+Node: Description (11)115021
+Ref: Usage and Customization115599
+Ref: On Startup115750
+Ref: Regularly116465
+Ref: Manually117398
+Node: Crafted Emacs Workspaces Module117997
+Node: Installation (12)118306
+Node: Description (12)118847
+Node: Crafted Emacs Writing Module120398
+Node: Installation (13)120664
+Node: Description (13)121190
+Ref: Whitespace Mode121717
+Ref: Function crafted-writing-configure-whitespace122183
+Ref: Signature122251
+Ref: Parameters122418
+Ref: Examples123335
+Ref: Optional Package PDF-Tools124444
+Ref: Part 1 Installing the Emacs package pdf-tools124790
+Ref: Part 2 Installing the epdfinfo-server125208
+Ref: Configuration125930
+Node: Troubleshooting126412
+Node: A package (suddenly?) fails to work126646
+Node: MIT License130418
 
 End Tag Table
 

--- a/docs/crafted-emacs.info
+++ b/docs/crafted-emacs.info
@@ -2309,12 +2309,18 @@ environment (IDE).
 
           Call ‘crafted-ide-configure-tree-sitter’ after requiring
           ‘crafted-ide-config’.  This will install all known language
-          grammars for Tree-Sitter.  To opt-out of one or more language
-          grammars, pass them as a list to
-          ‘crafted-ide-configure-tree-sitter’.  This can be useful if a
-          language grammar doesn't build on your setup or you generally
-          do not want a language grammar included as you would otherwise
-          be re-prompted to install new grammars on every Emacs startup.
+          grammars for Tree-Sitter.
+
+          Instead, you can pass a list of languages to
+          ‘crafted-ide-configure-tree-sitter’, then it will only install
+          those languages.  This can be also be useful if if a certain
+          language grammar doesn't successfully build on your setup, as
+          you would otherwise be re-prompted to install new grammars on
+          every Emacs startup.
+
+          See the tree-sitter website
+          (https://tree-sitter.github.io/tree-sitter/#parsers) for a
+          list of supported languages.
 
 
                (require 'crafted-ide-config)
@@ -2322,8 +2328,8 @@ environment (IDE).
                ;; install all language grammars
                (crafted-ide-configure-tree-sitter)
 
-               ;; install all language grammars, except protobuf
-               (crafted-ide-configure-tree-sitter '(protobuf))
+               ;; install only css, html and python
+               (crafted-ide-configure-tree-sitter '(css html python))
 
 
        3. Combobulate
@@ -3075,6 +3081,24 @@ while leaving them turned off for others.
           (customize-set-variable 'crafted-ui-line-numbers-enabled-modes
                                   '(conf-mode prog-mode markdown-mode))
 
+  3. Breadcrumb
+
+     The breadcrumb package uses information from ‘imenu.el’ and
+     ‘project.el’ to display helpful to provide orientation within a
+     file and/or project.
+
+     By default, the global mode of the breadcrumb package is activated:
+     ‘breadcrumb-mode’.  The breadcrumbs ar displayed at the top of the
+     window.
+
+     That behaviour can be tweaked in various ways, see the package's
+     ELPA page (https://elpa.gnu.org/packages/breadcrumb.html) or GitHub
+     repository (https://github.com/joaotavora/breadcrumb) for details.
+
+     The package also provides the command ‘breadcrumb-jump’ which is
+     similar to ‘imenu’ but displays the data extracted from both
+     ‘imenu.el’ and ‘project.el’.
+
 
 File: crafted-emacs.info,  Node: Crafted Emacs Updates Module,  Next: Crafted Emacs Workspaces Module,  Prev: Crafted Emacs UI Module,  Up: Modules
 
@@ -3582,65 +3606,66 @@ Ref: Automatically start Eglot when visiting language buffers85280
 Ref: Tree-Sitter85917
 Ref: Configuring Tree-Sitter (Emacs 28 or earlier)86250
 Ref: Configuring Tree-Sitter (Emacs 29 or later)86682
-Ref: Combobulate87569
-Node: Crafted Emacs Lisp Module88376
-Node: Installation (4)88688
-Node: Description (4)89195
-Ref: Emacs Lisp89795
-Ref: Common Lisp90507
-Ref: Clojure91373
-Ref: Scheme and Racket92009
-Node: Additional packages geiser-*92605
-Node: Crafted Emacs Org Module93649
-Node: Installation (5)93959
-Node: Description (5)94461
-Node: Alternative package org-roam96478
-Node: Crafted Emacs OSX Module98282
-Node: Installation (6)98565
-Node: Description (6)98877
-Node: Crafted Emacs Screencast Module99911
-Node: Installation (7)100213
-Node: Description (7)100750
-Node: Crafted Emacs Speedbar Module101451
-Node: Installation (8)101753
-Node: Description (8)102224
-Node: Crafted Emacs Startup Module104727
-Node: Installation (9)105093
-Node: Description (9)105563
-Node: Logo105860
-Node: Updates106978
-Node: Modules (1)107472
-Node: Turn off splash screen109526
-Node: Crafted Emacs UI Module110042
-Node: Installation (10)110327
-Node: Description (10)110828
-Ref: Icons with all-the-icons111557
-Ref: Line numbers112070
-Node: Crafted Emacs Updates Module113361
-Node: Installation (11)113659
-Node: Description (11)114131
-Ref: Usage and Customization114709
-Ref: On Startup114860
-Ref: Regularly115575
-Ref: Manually116508
-Node: Crafted Emacs Workspaces Module117107
-Node: Installation (12)117416
-Node: Description (12)117957
-Node: Crafted Emacs Writing Module119508
-Node: Installation (13)119774
-Node: Description (13)120300
-Ref: Whitespace Mode120827
-Ref: Function crafted-writing-configure-whitespace121293
-Ref: Signature121361
-Ref: Parameters121528
-Ref: Examples122445
-Ref: Optional Package PDF-Tools123554
-Ref: Part 1 Installing the Emacs package pdf-tools123900
-Ref: Part 2 Installing the epdfinfo-server124318
-Ref: Configuration125040
-Node: Troubleshooting125522
-Node: A package (suddenly?) fails to work125756
-Node: MIT License129528
+Ref: Combobulate87716
+Node: Crafted Emacs Lisp Module88523
+Node: Installation (4)88835
+Node: Description (4)89342
+Ref: Emacs Lisp89942
+Ref: Common Lisp90654
+Ref: Clojure91520
+Ref: Scheme and Racket92156
+Node: Additional packages geiser-*92752
+Node: Crafted Emacs Org Module93796
+Node: Installation (5)94106
+Node: Description (5)94608
+Node: Alternative package org-roam96625
+Node: Crafted Emacs OSX Module98429
+Node: Installation (6)98712
+Node: Description (6)99024
+Node: Crafted Emacs Screencast Module100058
+Node: Installation (7)100360
+Node: Description (7)100897
+Node: Crafted Emacs Speedbar Module101598
+Node: Installation (8)101900
+Node: Description (8)102371
+Node: Crafted Emacs Startup Module104874
+Node: Installation (9)105240
+Node: Description (9)105710
+Node: Logo106007
+Node: Updates107125
+Node: Modules (1)107619
+Node: Turn off splash screen109673
+Node: Crafted Emacs UI Module110189
+Node: Installation (10)110474
+Node: Description (10)110975
+Ref: Icons with all-the-icons111704
+Ref: Line numbers112217
+Ref: Breadcrumb113513
+Node: Crafted Emacs Updates Module114260
+Node: Installation (11)114558
+Node: Description (11)115030
+Ref: Usage and Customization115608
+Ref: On Startup115759
+Ref: Regularly116474
+Ref: Manually117407
+Node: Crafted Emacs Workspaces Module118006
+Node: Installation (12)118315
+Node: Description (12)118856
+Node: Crafted Emacs Writing Module120407
+Node: Installation (13)120673
+Node: Description (13)121199
+Ref: Whitespace Mode121726
+Ref: Function crafted-writing-configure-whitespace122192
+Ref: Signature122260
+Ref: Parameters122427
+Ref: Examples123344
+Ref: Optional Package PDF-Tools124453
+Ref: Part 1 Installing the Emacs package pdf-tools124799
+Ref: Part 2 Installing the epdfinfo-server125217
+Ref: Configuration125939
+Node: Troubleshooting126421
+Node: A package (suddenly?) fails to work126655
+Node: MIT License130427
 
 End Tag Table
 

--- a/docs/crafted-ide.org
+++ b/docs/crafted-ide.org
@@ -97,7 +97,7 @@ This will install all known language grammars for Tree-Sitter.
 
 Instead, you can pass a list of languages to ~crafted-ide-configure-tree-sitter~,
 then it will only install those languages.
-This can be also be useful if if a certain language grammar doesn't
+This can be also be useful if a certain language grammar doesn't
 successfully build on your setup, as you would otherwise be re-prompted to
 install new grammars on every Emacs startup.
 

--- a/docs/crafted-ide.org
+++ b/docs/crafted-ide.org
@@ -94,11 +94,14 @@ install language grammars.
 
 Call ~crafted-ide-configure-tree-sitter~ after requiring ~crafted-ide-config~.
 This will install all known language grammars for Tree-Sitter.
-To opt-out of one or more language grammars, pass them as a list
-to ~crafted-ide-configure-tree-sitter~.
-This can be useful if a language grammar doesn't build on your setup
-or you generally do not want a language grammar included as you would
-otherwise be re-prompted to install new grammars on every Emacs startup.
+
+Instead, you can pass a list of languages to ~crafted-ide-configure-tree-sitter~,
+then it will only install those languages.
+This can be also be useful if if a certain language grammar doesn't
+successfully build on your setup, as you would otherwise be re-prompted to
+install new grammars on every Emacs startup.
+
+See the [[https://tree-sitter.github.io/tree-sitter/#parsers][tree-sitter website]] for a list of supported languages.
 
 #+begin_src emacs-lisp
 
@@ -107,8 +110,8 @@ otherwise be re-prompted to install new grammars on every Emacs startup.
 ;; install all language grammars
 (crafted-ide-configure-tree-sitter)
 
-;; install all language grammars, except protobuf
-(crafted-ide-configure-tree-sitter '(protobuf))
+;; install only css, html and python
+(crafted-ide-configure-tree-sitter '(css html python))
 
 #+end_src
 

--- a/docs/crafted-ui.org
+++ b/docs/crafted-ui.org
@@ -79,11 +79,11 @@ For example:
 
 *** Breadcrumb
 
-The breadcrumb package uses information from =imenu.el= and =project.el= to display
-helpful to provide orientation within a file and/or project.
+The breadcrumb package displays helpful information from =imenu.el= and
+=project.el= to provide orientation within a file and/or project.
 
 By default, the global mode of the breadcrumb package is activated:
-~breadcrumb-mode~. The breadcrumbs ar displayed at the top of the window.
+~breadcrumb-mode~. The breadcrumbs are displayed at the top of the window.
 
 That behaviour can be tweaked in various ways, see the package's [[https://elpa.gnu.org/packages/breadcrumb.html][ELPA page]] or
 [[https://github.com/joaotavora/breadcrumb][GitHub repository]] for details.

--- a/docs/crafted-ui.org
+++ b/docs/crafted-ui.org
@@ -76,3 +76,17 @@ For example:
   (customize-set-variable 'crafted-ui-line-numbers-enabled-modes
                           '(conf-mode prog-mode markdown-mode))
 #+end_src
+
+*** Breadcrumb
+
+The breadcrumb package uses information from =imenu.el= and =project.el= to display
+helpful to provide orientation within a file and/or project.
+
+By default, the global mode of the breadcrumb package is activated:
+~breadcrumb-mode~. The breadcrumbs ar displayed at the top of the window.
+
+That behaviour can be tweaked in various ways, see the package's [[https://elpa.gnu.org/packages/breadcrumb.html][ELPA page]] or
+[[https://github.com/joaotavora/breadcrumb][GitHub repository]] for details.
+
+The package also provides the command ~breadcrumb-jump~ which is similar to ~imenu~
+but displays the data extracted from both =imenu.el= and =project.el=.


### PR DESCRIPTION
- Reflects the changed behaviour of `crafted-ide-configure-tree-sitter` introduced in 39617b7, by which it  is no longer opt-out, but opt-in when parameters are provided.
- A bit more info about the breadcrumbs package now provided by `crafted-ui`