### PR TITLE
[Emacs 30.1] Add configuration for global-completion-preview

### DIFF
--- a/modules/crafted-completion-config.el
+++ b/modules/crafted-completion-config.el
@@ -30,7 +30,11 @@
     (fido-mode -1)
     (fido-vertical-mode -1)
     (icomplete-mode -1)
-    (icomplete-vertical-mode -1)))
+    (icomplete-vertical-mode -1)
+    (when (version< "30" emacs-version)
+      ;; this mode is only available in Emacs version 30.1 and
+      ;; greater.
+      (global-completion-preview-mode -1))))
 
 
 ;;; Marginalia

--- a/modules/crafted-completion-config.el
+++ b/modules/crafted-completion-config.el
@@ -30,11 +30,7 @@
     (fido-mode -1)
     (fido-vertical-mode -1)
     (icomplete-mode -1)
-    (icomplete-vertical-mode -1)
-    (when (version< "30" emacs-version)
-      ;; this mode is only available in Emacs version 30.1 and
-      ;; greater.
-      (global-completion-preview-mode -1))))
+    (icomplete-vertical-mode -1)))
 
 
 ;;; Marginalia
@@ -83,6 +79,11 @@
 ;;; Corfu
 (when (require 'corfu nil :noerror)
 
+  (when (version< "30" emacs-version)
+    ;; this mode is only available in Emacs version 30.1 and
+    ;; greater.
+    (global-completion-preview-mode -1))
+  
   (unless (display-graphic-p)
     (when (require 'corfu-terminal nil :noerror)
       (corfu-terminal-mode +1)))

--- a/modules/crafted-defaults-config.el
+++ b/modules/crafted-defaults-config.el
@@ -89,6 +89,17 @@ also enables undo functionality if the window layout changes."
       (icomplete-mode 1))
   (fido-vertical-mode 1))
 
+;; Emacs version 30.1 introduced `global-completion-preview-mode'
+;; which provides completion previews in the editing buffer rather
+;; than in the minibuffer similar to other packages like `corfu'.
+(when (version< "30" emacs-version)
+  (global-completion-preview-mode 1)
+  ;; also bind M-n/M-p to next/previous completion
+  ;; by default C-i is bound to #'completion-preview-insert and
+  ;; M-i is bound to #'completion-preview-complete
+  (keymap-set completion-preview-active-mode-map "M-n" #'completion-preview-next-candidate)
+  (keymap-set completion-preview-active-mode-map "M-p" #'completion-preview-prev-candidate))
+
 ;; No matter which completion mode is used:
 (customize-set-variable 'tab-always-indent 'complete)
 (customize-set-variable 'completion-cycle-threshold 3)


### PR DESCRIPTION
Adds configuration for global-completion-preview in the crafted-defaults-config module. 

Closes #431 