### PR TITLE
Remove deprecated configurations for marginalia

### DIFF
--- a/modules/crafted-completion-config.el
+++ b/modules/crafted-completion-config.el
@@ -35,11 +35,6 @@
 
 ;;; Marginalia
 (when (require 'marginalia nil :noerror)
-  ;; Configure Marginalia
-  (customize-set-variable 'marginalia-annotators
-                          '(marginalia-annotators-heavy
-                            marginalia-annotators-light
-                            nil))
   (marginalia-mode 1))
 
 


### PR DESCRIPTION
The marginalia-annotators variable from package marginalia has been deprecated and removed in 2021.

* Deprecation commit: https://github.com/minad/marginalia/commit/ac4ab987126c0366b876e7fdcfa797822dd3580b
* Removal commit: https://github.com/minad/marginalia/commit/b60d784802e2dbeb0ed04897c1d0d19e9ae7918e