### PR TITLE
feat: add exec-path-from-shell to the IDE module

### DIFF
--- a/docs/crafted-ide.org
+++ b/docs/crafted-ide.org
@@ -27,7 +27,8 @@ This module includes:
 - LSP client (Eglot)
 - Next-generation syntax parsing (Tree-Sitter)
 - [[https://editorconfig.org][EditorConfig]] support ([[https://github.com/editorconfig/editorconfig-emacs][editorconfig-emacs]]).
-
+- Environment-variables setup
+  
 *** Aggressive Indentation
 
 By default Emacs enables [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Indent-Convenience.html][Electric Indent]], a minor mode that
@@ -127,3 +128,21 @@ See [[https://github.com/mickeynp/combobulate][Combobulate]] for details.
 If you're interested in a more in-depth look at both Tree-Stitter and
 Combobulate, the author of the package has written an extensive blog post
 about it: [[https://www.masteringemacs.org/article/combobulate-structured-movement-editing-treesitter][Combobulate: Structured Movement and Editing with Tree-Sitter]].
+
+*** Environment-Variables Setup
+
+Many Emacs IDE features depend on external tools, such as, LSP servers,
+interpreters, compilers, and linters. To ensure Emacs can locate the
+executables for these tools, both the environment variables and the =exec-path=
+variable (see [[info:Emacs#Shell][info "(Emacs) Shell"]]) must be configured correctly.
+
+This setup is especially critical when Emacs is launched from a desktop
+environment using a launcher, rather than from a shell. In such cases, Emacs
+typically inherits a minimal set of environment variables, which may not
+include those available in a shell session. As a result, executables might not
+be found, and configurations relying on specific environment variables may
+fail.
+
+The =exec-path-from-shell= package (see [[https://github.com/purcell/exec-path-from-shell][Website]]) addresses this issue by setting
+=exec-path= and predefined environment variables as if Emacs were started from a
+shell.

--- a/modules/crafted-ide-config.el
+++ b/modules/crafted-ide-config.el
@@ -16,6 +16,23 @@
 
 ;;; Code:
 
+;;; exec-path-from-shell
+;; Ensure that environment variables inside Emacs look the same as in the
+;; user's shell.  This is especially useful when Emacs is launched with a
+;; desktop launcher (and not from a shell).  In this case, Emacs usually
+;; inherits a default minimal set of environment variables and not the set of
+;; environment variables that are available inside of a shell.  This can lead
+;; to executables not being found or configurations that rely on certain
+;; environment variables not working.  `exec-path-from-shell' prevents the
+;; problem by setting `exec-path' and predefined environment variables as if
+;; Emacs were started from shell.
+(when (require 'exec-path-from-shell nil :noerror)
+  ;; Specify environment variables that will be copied (note, "PATH" and
+  ;; "MANPATH" has been already added by default).
+  (dolist (var '("SSH_AUTH_SOCK" "SSH_AGENT_PID" "GPG_AGENT_INFO" "LANG"
+                 "LC_CTYPE" "GOPATH" "PYTHONPATH" "JAVA_HOME"))
+    (add-to-list 'exec-path-from-shell-variables var))
+  (exec-path-from-shell-initialize))
 
 ;;; Eglot
 (defun crafted-ide--add-eglot-hooks (mode-list)

--- a/modules/crafted-ide-packages.el
+++ b/modules/crafted-ide-packages.el
@@ -46,5 +46,13 @@
 ;; group project buffers together when listing buffers with ibuffer
 (add-to-list 'package-selected-packages 'ibuffer-project)
 
+;;; Environment-Variables Setup
+;; Emacs IDE features often rely on external tools (such as, LSP servers,
+;; interpreters, compilers, linters, etc).  This package ensures that Emacs
+;; knows where the executables of these tools are located.
+(when (or (display-graphic-p)
+          (daemonp))
+  (add-to-list 'package-selected-packages 'exec-path-from-shell))
+
 (provide 'crafted-ide-packages)
 ;;; crafted-ide-packages.el ends here


### PR DESCRIPTION
Many Emacs IDE features depend on external tools, such as, LSP servers, interpreters, compilers, and linters. To ensure Emacs can locate the executables for these tools, both the environment variables and the exec-path variable (see "(Emacs) Shell") must be configured correctly.