### PR TITLE
fix: remove the advice with the deprecated `cape-wrap-purify`

### DIFF
--- a/modules/crafted-completion-config.el
+++ b/modules/crafted-completion-config.el
@@ -111,10 +111,6 @@
   ;; Important for corfu
   (advice-add 'pcomplete-completions-at-point :around #'cape-wrap-silent)
 
-  ;; Ensure that pcomplete does not write to the buffer
-  ;; and behaves as a pure `completion-at-point-function'.
-  (advice-add 'pcomplete-completions-at-point :around #'cape-wrap-purify)
-
   ;; No auto-completion or completion-on-quit in eshell
   (defun crafted-completion-corfu-eshell ()
     "Special settings for when using corfu with eshell."


### PR DESCRIPTION
Cape has deprecated `cape-wrap-purify` since version 2.3, because starting with Emacs 29 this workaround is not needed anymore.

Refs:
- https://github.com/minad/cape/blob/main/CHANGELOG.org#version-23-2025-11-15
- https://github.com/minad/cape/blob/2e86b6deed2844fc1345ff01bc92c3a849a33778/cape.el#L1207